### PR TITLE
Reverse allow/possible serial check

### DIFF
--- a/src/install-update/install-update-dialog.ts
+++ b/src/install-update/install-update-dialog.ts
@@ -88,7 +88,6 @@ class ESPHomeInstallDialog extends LitElement {
 
     if (this._state === "pick_option") {
       heading = "Pick Install Target";
-      const doWebSerial = supportsWebSerial && allowsWebSerial;
       content = html`
         <mwc-list-item
           twoline
@@ -106,13 +105,13 @@ class ESPHomeInstallDialog extends LitElement {
         <mwc-list-item twoline hasMeta @click=${this._handleBrowserInstall}>
           <span>Install via the browser</span>
           <span slot="secondary">
-            ${doWebSerial
+            ${supportsWebSerial
               ? "For devices connected to this computer"
               : allowsWebSerial
               ? "Your browser is not supported."
               : "Dashboard needs to opened via HTTPS"}
           </span>
-          ${doWebSerial ? metaChevronRight : metaHelp}
+          ${supportsWebSerial ? metaChevronRight : metaHelp}
         </mwc-list-item>
 
         <mwc-list-item twoline hasMeta @click=${this._showServerPorts}>

--- a/src/install-update/install-update-dialog.ts
+++ b/src/install-update/install-update-dialog.ts
@@ -108,9 +108,9 @@ class ESPHomeInstallDialog extends LitElement {
           <span slot="secondary">
             ${doWebSerial
               ? "For devices connected to this computer"
-              : supportsWebSerial
-              ? "Dashboard needs to opened via HTTPS"
-              : "Your browser is not supported."}
+              : allowsWebSerial
+              ? "Your browser is not supported."
+              : "Dashboard needs to opened via HTTPS"}
           </span>
           ${doWebSerial ? metaChevronRight : metaHelp}
         </mwc-list-item>

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -158,7 +158,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
   private _renderBasicConfig() {
     return html`
-      ${supportsWebSerial && allowsWebSerial
+      ${supportsWebSerial
         ? ""
         : html`
             <div class="notice">

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -163,7 +163,7 @@ export class ESPHomeWizardDialog extends LitElement {
         : html`
             <div class="notice">
               Limited functionality because
-              ${!supportsWebSerial
+              ${allowsWebSerial
                 ? html`
                     your browser does not support WebSerial.
                     <a


### PR DESCRIPTION
Warn first if web serial would not be allowed because the context is not secure before checking if web serial is possible. 

If web serial is not allowed, it will also be detected as not supported.