### PR TITLE
Fix save on intall from editor

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -83,7 +83,7 @@ export const openEditDialog = (filename) => {
   );
   saveButton.setAttribute("data-filename", editorActiveFilename);
   uploadButton.setAttribute("data-filename", editorActiveFilename);
-  uploadButton.setAttribute("onClick", `saveFile("${editorActiveFilename}")`);
+  uploadButton.onclick = () => saveFile(editorActiveFilename);
   if (editorActiveFilename === "secrets.yaml") {
     uploadButton.classList.add("disabled");
     editorActiveSecrets = true;


### PR DESCRIPTION
This function is called multiple times. Originally it would take "saveFile" from the global scope but that's no longer available.

I directly assign to `onclick` such that we override any previous click listener attached that way. Little hacky but this whole method will be migrated to the modern approach in the future anyway.

Fixes #21