### PR TITLE
Update esp web flasher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@material/mwc-list": "^0.21.0",
         "@material/mwc-radio": "^0.21.0",
         "@material/mwc-textfield": "^0.21.0",
-        "esp-web-flasher": "^3.0.0",
+        "esp-web-flasher": "^3.1.0",
         "lit": "^2.0.0-rc.2",
         "tslib": "^2.3.0"
       },
@@ -963,9 +963,9 @@
       }
     },
     "node_modules/esp-web-flasher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/esp-web-flasher/-/esp-web-flasher-3.0.0.tgz",
-      "integrity": "sha512-xddZ3UCBLCskHV5hVu8Fc8Sj8aB/opMell3DcUa8LMgsUau6o1Tlr8w9JoGyadD2aKmanCU1RADjX8oa56W+xA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/esp-web-flasher/-/esp-web-flasher-3.1.0.tgz",
+      "integrity": "sha512-ezzkYa+/nu82tHhyKr7HFJW9WOuKqS1QFEzMNSa/o356q2fPz3Aqyd+UGGOt1hV97jdjrbpjux1n+wTsoi8XKQ==",
       "dependencies": {
         "pako": "^2.0.3",
         "tslib": "^2.2.0"
@@ -1531,6 +1531,9 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.2.tgz",
       "integrity": "sha512-4RlFC3k2BIHlUsJ9mGd8OO+9Lm2eDF5P7+6DNQOp5sx+7N/1tFM01kELfbxlMX3MxT6owvLB1ln4S3QvvQlbUA==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.2"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2762,9 +2765,9 @@
       "dev": true
     },
     "esp-web-flasher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/esp-web-flasher/-/esp-web-flasher-3.0.0.tgz",
-      "integrity": "sha512-xddZ3UCBLCskHV5hVu8Fc8Sj8aB/opMell3DcUa8LMgsUau6o1Tlr8w9JoGyadD2aKmanCU1RADjX8oa56W+xA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/esp-web-flasher/-/esp-web-flasher-3.1.0.tgz",
+      "integrity": "sha512-ezzkYa+/nu82tHhyKr7HFJW9WOuKqS1QFEzMNSa/o356q2fPz3Aqyd+UGGOt1hV97jdjrbpjux1n+wTsoi8XKQ==",
       "requires": {
         "pako": "^2.0.3",
         "tslib": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@material/mwc-list": "^0.21.0",
     "@material/mwc-radio": "^0.21.0",
     "@material/mwc-textfield": "^0.21.0",
-    "esp-web-flasher": "^3.0.0",
+    "esp-web-flasher": "^3.1.0",
     "lit": "^2.0.0-rc.2",
     "tslib": "^2.3.0"
   }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,8 @@
-import { CHIP_FAMILY_ESP32, CHIP_FAMILY_ESP8266 } from "esp-web-flasher";
+import {
+  CHIP_FAMILY_ESP32,
+  CHIP_FAMILY_ESP8266,
+  // @ts-ignore
+} from "esp-web-flasher/dist/web";
 import { svg } from "lit";
 
 export const supportsWebSerial = "serial" in navigator;

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -1,4 +1,5 @@
-import { ESPLoader } from "esp-web-flasher";
+// @ts-ignore
+import { ESPLoader } from "esp-web-flasher/dist/web";
 import { getConfiguration } from "./api/configuration";
 import { chipFamilyToPlatform } from "./const";
 
@@ -63,7 +64,7 @@ export const flashConfiguration = async (
     const file = files.shift()!;
     await espStub.flashData(
       file,
-      (bytesWritten) => {
+      (bytesWritten: number) => {
         const newPct = Math.floor(
           ((totalWritten + bytesWritten) / totalSize) * 100
         );
@@ -73,7 +74,8 @@ export const flashConfiguration = async (
         lastPct = newPct;
         writeProgress(newPct);
       },
-      part.offset
+      part.offset,
+      true
     );
     totalWritten += file.byteLength;
   }

--- a/src/install-update/install-dialog.ts
+++ b/src/install-update/install-dialog.ts
@@ -15,7 +15,8 @@ import "@material/mwc-dialog";
 import "@material/mwc-list/mwc-list-item.js";
 import "@material/mwc-circular-progress";
 import "@material/mwc-button";
-import { connect, ESPLoader } from "esp-web-flasher";
+// @ts-ignore
+import { connect, ESPLoader } from "esp-web-flasher/dist/web";
 import { allowsWebSerial, metaChevronRight, supportsWebSerial } from "../const";
 import {
   compileConfiguration,

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -12,7 +12,8 @@ import {
   ESPLoader,
   CHIP_FAMILY_ESP32,
   CHIP_FAMILY_ESP8266,
-} from "esp-web-flasher";
+  // @ts-ignore
+} from "esp-web-flasher/dist/web";
 import { allowsWebSerial, supportsWebSerial } from "../const";
 import {
   compileConfiguration,


### PR DESCRIPTION
Update ESP Web Flasher to 3.1.0 and enable compression.

There is an issue in the 3.x series and the unbundled version doesn't work well with rollup. Temporarily importing from `/dist/web` as a workaround.