### PR TITLE
Unexcepted result in content-type

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,7 +10,7 @@ export const fetchApi = async <T>(
   if (!resp.ok) {
     throw new Error(`Request not successful (${resp.status})`);
   }
-  return resp.headers.get("content-type") === "application/json"
+  return resp.headers.get("content-type").indexOf("application/json") !== -1
     ? resp.json()
     : resp.text();
 };


### PR DESCRIPTION
`resp.headers.get("content-type")` can return `application/json; charset=utf-8` which fails the check.

Please see https://github.com/esphome/issues/issues/2183
This could fix: https://github.com/esphome/issues/issues/2183 , https://github.com/esphome/issues/issues/2193

The problem is here, `ports` is not a array but plain text.
https://github.com/esphome/dashboard/blob/ed3eed004e99068e2cb3453f7fe8820ec72a0e9a/src/api/serial-ports.ts#L12

Then fetchApi doesn't appear to return a javascript array but regular text.
Which is wierd because this is checked here: https://github.com/esphome/dashboard/blob/ed3eed004e99068e2cb3453f7fe8820ec72a0e9a/src/api/index.ts#L13-L15

This is not a browser cache problem.
`/serial-ports` does indeed return a json text, and the `content-type: application/json; charset=utf-8` header.

And that's where it goes wrong.
In my testing, `resp.headers.get("content-type")` returned: `application/json; charset=utf-8` which is not the same as `application/json`.
I'm not quite sure where the `charset=utf-8` comes from, but this PR fixes the issue quite easly.

Another posibility is to force `resp.json()` wrapped in a try / catch.
```
try {
    return resp.json();
} catch(err) {
   return resp.text();
}
```

