### PR TITLE
Fix JSON parse error when backend returns 304

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "esphome-dashboard",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -1,4 +1,4 @@
-import { fetchApi, streamLogs } from ".";
+import { fetchApiJson, fetchApiText, streamLogs } from ".";
 
 export interface CreateConfigParams {
   name: string;
@@ -24,16 +24,16 @@ export interface Configuration {
 }
 
 export const createConfiguration = (params: CreateConfigParams) =>
-  fetchApi("./wizard.html", {
+  fetchApiText("./wizard.html", {
     method: "post",
     body: new URLSearchParams(params as any),
   });
 
 export const getConfiguration = (configuration: string) =>
-  fetchApi<Configuration>(`./info?configuration=${configuration}`);
+  fetchApiJson<Configuration>(`./info?configuration=${configuration}`);
 
 export const deleteConfiguration = (configuration: string) =>
-  fetchApi(`./delete?configuration=${configuration}`, {
+  fetchApiText(`./delete?configuration=${configuration}`, {
     method: "post",
   });
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,7 +1,7 @@
-export const fetchApi = async <T>(
+const fetchApiBase = async (
   path: Parameters<typeof fetch>[0],
   options?: Parameters<typeof fetch>[1]
-): Promise<T> => {
+): ReturnType<typeof fetch> => {
   if (!options) {
     options = {};
   }
@@ -10,9 +10,23 @@ export const fetchApi = async <T>(
   if (!resp.ok) {
     throw new Error(`Request not successful (${resp.status})`);
   }
-  return resp.headers.get("content-type").indexOf("application/json") !== -1
-    ? resp.json()
-    : resp.text();
+  return resp;
+}
+
+export const fetchApiText = async (
+  path: Parameters<typeof fetch>[0],
+  options?: Parameters<typeof fetch>[1]
+): Promise<string> => {
+  const resp = await fetchApiBase(path, options);
+  return resp.text();
+};
+
+export const fetchApiJson = async <T>(
+  path: Parameters<typeof fetch>[0],
+  options?: Parameters<typeof fetch>[1]
+): Promise<T> => {
+  const resp = await fetchApiBase(path, options);
+  return resp.json();
 };
 
 export class StreamError extends Error {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,7 +11,7 @@ const fetchApiBase = async (
     throw new Error(`Request not successful (${resp.status})`);
   }
   return resp;
-}
+};
 
 export const fetchApiText = async (
   path: Parameters<typeof fetch>[0],

--- a/src/api/ping.ts
+++ b/src/api/ping.ts
@@ -1,4 +1,4 @@
-import { fetchApi } from ".";
+import { fetchApiJson } from ".";
 
 export const getOnlineStatus = () =>
-  fetchApi<Record<string, boolean>>("./ping");
+  fetchApiJson<Record<string, boolean>>("./ping");

--- a/src/api/serial-ports.ts
+++ b/src/api/serial-ports.ts
@@ -1,4 +1,4 @@
-import { fetchApi } from ".";
+import { fetchApiJson } from ".";
 
 export interface SerialPort {
   desc: string;
@@ -6,7 +6,7 @@ export interface SerialPort {
 }
 
 export const getSerialPorts = () =>
-  fetchApi<SerialPort[]>("./serial-ports")
+  fetchApiJson<SerialPort[]>("./serial-ports")
     // We don't care about OTA but can't remove yet
     // until all legacy JS is gone
     .then((ports) => ports.filter((port) => port.port !== "OTA"));


### PR DESCRIPTION
For some URLs (namely /ping and /serial-ports) tornado will automatically set an ETag Header with the hashed payload.

When there's a cache hit, the backend only returns 304 Not Modified.

HTTP Request/response:

```
GET /serial-ports HTTP/1.1
Host: localhost:6052
# ...
If-None-Match: "49b6fc370dd17e5696abd7a3294d834fac2cccd5"
Cache-Control: max-age=0


HTTP/1.1 304 Not Modified
Server: TornadoServer/6.1
Date: Thu, 05 Aug 2021 16:40:49 GMT
Etag: "49b6fc370dd17e5696abd7a3294d834fac2cccd5"
```

Importantly, for 304 Not Modified the `content-type` header is _not_ sent (the HTTP RFC also specifies 304 to act just like that https://stackoverflow.com/a/31107285)

I know it's an ugly fix, but I couldn't find a way to disable the behavior in the backend (tornado has horrible docs). So instead fix it in the frontend (where ideally it should be fixed anyway, because the HTTP RFC recommends this behavior)

