### PR TITLE
Bump esp-web-flasher to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "esphome-dashboard",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1531,6 +1532,9 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
       "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.2"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@material/mwc-list": "^0.22.1",
     "@material/mwc-radio": "^0.22.1",
     "@material/mwc-textfield": "^0.22.1",
-    "esp-web-flasher": "^3.1.3",
+    "esp-web-flasher": "^3.2.0",
     "lit": "^2.0.0-rc.3",
     "tslib": "^2.3.1"
   }


### PR DESCRIPTION
Changelog: https://github.com/NabuCasa/esp-web-flasher/releases/tag/3.2.0

Tested with both ESP32 and ESP8266.