### PR TITLE
Fix web_server button not showing up

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -38,7 +38,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
       >
         <div class="card-header">
           ${this.device.name}
-          ${"web_server" in this.device.loaded_integrations
+          ${this.device.loaded_integrations.includes("web_server")
             ? html`
                 <div class="tooltip-container">
                   <a href=${`http://${this.entry.address}`} target="_blank">


### PR DESCRIPTION
`in` works for objects keys, but not array items

bug introduced with #76

See esphome/issues#2515