### PR TITLE
Fix web_server break device card

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -41,7 +41,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
           ${this.device.loaded_integrations.includes("web_server")
             ? html`
                 <div class="tooltip-container">
-                  <a href=${`http://${this.entry.address}`} target="_blank">
+                  <a href=${`http://${this.device.address}`} target="_blank">
                     <mwc-icon>launch</mwc-icon>
                   </a>
                   <paper-tooltip>


### PR DESCRIPTION
Typo from a refactor, previously the property was called `entry`, but I changed it to `device` for consistency. Forgot to rename it here