### PR TITLE
Make update button clickable

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -42,7 +42,10 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
             ? html`
                 <div class="tooltip-container">
                   <a href=${`http://${this.device.address}`} target="_blank">
-                    <mwc-icon>launch</mwc-icon>
+                    <mwc-icon-button
+                      icon="launch"
+                      label="Open web UI"
+                    ></mwc-icon-button>
                   </a>
                   <paper-tooltip>
                     Open device web server interface
@@ -53,7 +56,12 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
           ${this.device.deployed_version != this.device.current_version
             ? html`
                 <div class="tooltip-container">
-                  <mwc-icon class="update-available">system_update</mwc-icon>
+                  <mwc-icon-button
+                    @click=${this._handleInstall}
+                    class="update-available"
+                    icon="system_update"
+                    label="Install Update"
+                  ></mwc-icon-button>
                   <paper-tooltip>
                     Update Available: ${this.device.deployed_version}
                     ${UPDATE_TO_ICON} ${this.device.current_version}


### PR DESCRIPTION
Inspired by #96. I didn't make it single click, but instead have clicking the icon open the install dialog. The reason for this is that I want to have a confirmation before doing an update, and if the device is offline we would show the install dialog, so this makes the experience consistent.