### PR TITLE
Hide online status if online

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -83,10 +83,13 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
             </paper-tooltip>
           </div>
 
-          <div class="online-status">
-            <span class="indicator"></span>
-          </div>
-
+          ${this.onlineStatus === true
+            ? ""
+            : html`
+                <div class="online-status">
+                  <span class="indicator"></span>
+                </div>
+              `}
           ${this.device.comment ? html`<div>${this.device.comment}</div>` : ""}
         </div>
 


### PR DESCRIPTION
Hide the online status text if the device is online. Only show the text if the device is unknown or offline.

We initially had removed all text, but reinstated that because colorblind people could not distinguish the top border of the card. The "online" case is the positive case and should be assumed. We now only show "Unknown" or "Offline" (the error states).

![image](https://user-images.githubusercontent.com/1444314/137358929-b7690a51-3ac0-49f9-ab7a-cc0c6d0dace1.png)
