### PR TITLE
Hide the install button when we edit secrets

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -74,10 +74,10 @@ export const openEditDialog = (filename) => {
     editorActiveFilename === "secrets.yaml" ||
     editorActiveFilename === "secrets.yml"
   ) {
-    uploadButton.classList.add("disabled");
+    uploadButton.style.display = "none";
     editorActiveSecrets = true;
   } else {
-    uploadButton.classList.remove("disabled");
+    uploadButton.style.display = "";
     editorActiveSecrets = false;
   }
   closeButton.setAttribute("data-filename", editorActiveFilename);


### PR DESCRIPTION
The old logic added a disabled class. That doesn't work with the mwc-button. With secrets we now hide it instead.