### PR TITLE
Push card actions down

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -66,7 +66,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
 
         ${content.length
           ? html`<div class="card-content flex">${content}</div>`
-          : ""}
+          : html`<div class="flex"></div>`}
 
         <div class="card-actions">
           ${updateAvailable


### PR DESCRIPTION
Cards are stretching height but if it had no content, the actions weren't pushed down. Fixed now.

Before:

![image](https://user-images.githubusercontent.com/1444314/137989776-3a673e29-eee7-44ec-ae1c-94d72efa527f.png)


After:

![image](https://user-images.githubusercontent.com/1444314/137989684-634968a1-e76d-48b0-aa0b-d1b15d4a5084.png)
