### PR TITLE
Add wifi secrets to workflow

### DIFF
--- a/src/adopt/adopt-dialog.ts
+++ b/src/adopt/adopt-dialog.ts
@@ -1,0 +1,187 @@
+import { LitElement, html, css, PropertyValues } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import "@material/mwc-button";
+import "@material/mwc-dialog";
+import "@material/mwc-textfield";
+import type { TextField } from "@material/mwc-textfield";
+import { fireEvent } from "../util/fire-event";
+import { ImportableDevice, importDevice } from "../api/devices";
+import { checkHasWifiSecrets, storeWifiSecrets } from "../api/wifi";
+import { openInstallDialog } from "../install-update";
+
+@customElement("esphome-adopt-dialog")
+class ESPHomeAdoptDialog extends LitElement {
+  @property() public device!: ImportableDevice;
+
+  @state() private _hasWifiSecrets: boolean | undefined;
+
+  @state() private _adopted = false;
+  @state() private _busy = false;
+  @state() private _error?: string;
+
+  @query("mwc-textfield[name=ssid]") private _inputSSID!: TextField;
+  @query("mwc-textfield[name=password]") private _inputPassword!: TextField;
+
+  protected render() {
+    return html`
+      <mwc-dialog
+        .heading=${this._adopted ? "Configuration created" : `Adopt device`}
+        @closed=${this._handleClose}
+        open
+      >
+        ${this._adopted
+          ? html`
+              <div>
+                To finish adoption, the new configuration needs to be installed
+                on the device. This can be done wirelessly.
+              </div>
+              <mwc-button
+                slot="primaryAction"
+                dialogAction="install"
+                label="Install"
+                @click=${() => openInstallDialog(`${this.device.name}.yaml`)}
+              ></mwc-button>
+              <mwc-button
+                slot="secondaryAction"
+                dialogAction="skip"
+                label="skip"
+              ></mwc-button>
+            `
+          : html`
+              <div>
+                Adopting ${this.device.name} will create an ESPHome
+                configuration for this device allowing you to install updates
+                and customize the original firmware.
+              </div>
+
+              ${this._error
+                ? html`<div class="error">${this._error}</div>`
+                : ""}
+              ${this._hasWifiSecrets !== false
+                ? html`
+                    <div>
+                      This device will be configured to connect to the Wi-Fi
+                      network stored in your secrets.
+                    </div>
+                  `
+                : html`
+                    <div>
+                      Enter the credentials of the Wi-Fi network that you want
+                      your device to connect to.
+                    </div>
+                    <div>
+                      This information will be stored in your secrets and used
+                      for this and future devices. You can edit the information
+                      later by editing your secrets at the top of the page.
+                    </div>
+
+                    <mwc-textfield
+                      label="Network name"
+                      name="ssid"
+                      required
+                      @blur=${this._cleanSSIDBlur}
+                      .disabled=${this._busy}
+                    ></mwc-textfield>
+
+                    <mwc-textfield
+                      label="Password"
+                      name="password"
+                      type="password"
+                      helper="Leave blank if no password"
+                      .disabled=${this._busy}
+                    ></mwc-textfield>
+                  `}
+
+              <mwc-button
+                slot="primaryAction"
+                .label=${this._busy ? "Adopting…" : "Adopt"}
+                @click=${this._handleAdopt}
+                .disabled=${this._hasWifiSecrets === undefined}
+              ></mwc-button>
+              ${this._busy
+                ? ""
+                : html`
+                    <mwc-button
+                      slot="secondaryAction"
+                      label="Cancel"
+                      dialogAction="cancel"
+                    ></mwc-button>
+                  `}
+            `}
+      </mwc-dialog>
+    `;
+  }
+
+  protected firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
+    checkHasWifiSecrets().then((hasWifiSecrets) => {
+      this._hasWifiSecrets = hasWifiSecrets;
+    });
+  }
+
+  private _cleanSSIDBlur = (ev: Event) => {
+    const input = ev.target as TextField;
+    // Remove starting and trailing whitespace
+    input.value = input.value.trim();
+  };
+
+  private _handleClose() {
+    this.parentNode!.removeChild(this);
+  }
+
+  private async _handleAdopt() {
+    this._error = undefined;
+
+    if (this._hasWifiSecrets === false) {
+      if (!this._inputSSID.reportValidity()) {
+        this._inputSSID.focus();
+        return;
+      }
+
+      this._busy = true;
+
+      try {
+        await storeWifiSecrets(
+          this._inputSSID.value,
+          this._inputPassword.value
+        );
+      } catch (err) {
+        this._busy = false;
+        this._error = "Failed to store Wi-Fi credentials";
+        return;
+      }
+    }
+    this._busy = true;
+    try {
+      await importDevice(this.device);
+      fireEvent(this, "adopted");
+      this._adopted = true;
+    } catch (err) {
+      this._busy = false;
+      this._error = "Failed to import device";
+    }
+  }
+
+  static styles = css`
+    :host {
+      --mdc-dialog-max-width: 390px;
+    }
+    mwc-textfield {
+      display: block;
+      margin-top: 16px;
+    }
+    div + div {
+      margin-top: 16px;
+    }
+    .error {
+      color: #db4437;
+      margin-bottom: 16px;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-adopt-dialog": ESPHomeAdoptDialog;
+  }
+}

--- a/src/adopt/index.ts
+++ b/src/adopt/index.ts
@@ -1,0 +1,14 @@
+import { ImportableDevice } from "../api/devices";
+
+const preload = () => import("./adopt-dialog");
+
+export const openAdoptDialog = (
+  device: ImportableDevice,
+  onAdopt: () => void
+) => {
+  preload();
+  const dialog = document.createElement("esphome-adopt-dialog");
+  dialog.device = device;
+  dialog.addEventListener("adopted", onAdopt);
+  document.body.append(dialog);
+};

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -2,6 +2,8 @@ import { fetchApiJson, fetchApiText, streamLogs } from ".";
 
 export interface CreateConfigParams {
   name: string;
+  ssid: string;
+  psk: string;
   board: string;
   platform: "ESP8266" | "ESP32";
 }

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -2,8 +2,6 @@ import { fetchApiJson, fetchApiText, streamLogs } from ".";
 
 export interface CreateConfigParams {
   name: string;
-  ssid: string;
-  psk: string;
   board: string;
   platform: "ESP8266" | "ESP32";
 }

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -1,0 +1,22 @@
+import { APIError, fetchApiText } from ".";
+
+// null if file not found.
+export const getFile = async (filename: string): Promise<string | null> => {
+  try {
+    return fetchApiText(`./edit?configuration=${filename}`);
+  } catch (err) {
+    if (err instanceof APIError && err.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+};
+
+export const writeFile = async (
+  filename: string,
+  content: string
+): Promise<string> =>
+  fetchApiText(`./edit?configuration=${filename}`, {
+    method: "POST",
+    body: content,
+  });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,10 @@
+export class APIError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+    this.name = "APIError";
+  }
+}
+
 const fetchApiBase = async (
   path: Parameters<typeof fetch>[0],
   options?: Parameters<typeof fetch>[1]
@@ -8,7 +15,7 @@ const fetchApiBase = async (
   options.credentials = "same-origin";
   const resp = await fetch(path, options);
   if (!resp.ok) {
-    throw new Error(`Request not successful (${resp.status})`);
+    throw new APIError(`Request not successful (${resp.status})`, resp.status);
   }
   return resp;
 };

--- a/src/api/secrets.ts
+++ b/src/api/secrets.ts
@@ -1,0 +1,42 @@
+import { APIError, fetchApiJson } from ".";
+import { getFile, writeFile } from "./files";
+
+export const SECRETS_FILE = "secrets.yaml";
+
+export const getSecretKeys = async (): Promise<string[]> => {
+  try {
+    return await fetchApiJson("./secret_keys");
+  } catch (err: any) {
+    if (err instanceof APIError && err.status === 404) {
+      return [];
+    }
+    throw err;
+  }
+};
+
+export const appendSecrets = async (
+  secrets: Record<string, string>,
+  comment?: string
+): Promise<void> => {
+  let content = await getFile(SECRETS_FILE);
+  if (content === null) {
+    content = "";
+  }
+
+  let toAppend =
+    content.length === 0
+      ? ""
+      : content.charAt(content.length - 1) !== "\n"
+      ? "\n\n"
+      : "\n";
+
+  if (comment) {
+    toAppend += `# ${comment}\n`;
+  }
+
+  for (const [key, value] of Object.entries(secrets)) {
+    toAppend += `${key}: ${JSON.stringify(value)}\n`;
+  }
+
+  await writeFile(SECRETS_FILE, content + toAppend);
+};

--- a/src/api/wifi.ts
+++ b/src/api/wifi.ts
@@ -1,18 +1,20 @@
 import { appendSecrets, getSecretKeys } from "./secrets";
 
-const SECRET_SSID = "wifi_ssid";
-const SECRET_PASSWORD = "wifi_password";
+export const SECRET_WIFI_SSID = "wifi_ssid";
+export const SECRET_WIFI_PASSWORD = "wifi_password";
 
 export const checkHasWifiSecrets = async () => {
   const secrets = await getSecretKeys();
-  return secrets.includes(SECRET_SSID) && secrets.includes(SECRET_PASSWORD);
+  return (
+    secrets.includes(SECRET_WIFI_SSID) && secrets.includes(SECRET_WIFI_PASSWORD)
+  );
 };
 
 export const storeWifiSecrets = async (ssid: string, password: string) =>
   appendSecrets(
     {
-      [SECRET_SSID]: ssid,
-      [SECRET_PASSWORD]: password,
+      [SECRET_WIFI_SSID]: ssid,
+      [SECRET_WIFI_PASSWORD]: password,
     },
     "Your Wi-Fi SSID and password"
   );

--- a/src/api/wifi.ts
+++ b/src/api/wifi.ts
@@ -1,0 +1,18 @@
+import { appendSecrets, getSecretKeys } from "./secrets";
+
+const SECRET_SSID = "wifi_ssid";
+const SECRET_PASSWORD = "wifi_password";
+
+export const checkHasWifiSecrets = async () => {
+  const secrets = await getSecretKeys();
+  return secrets.includes(SECRET_SSID) && secrets.includes(SECRET_PASSWORD);
+};
+
+export const storeWifiSecrets = async (ssid: string, password: string) =>
+  appendSecrets(
+    {
+      [SECRET_SSID]: ssid,
+      [SECRET_PASSWORD]: password,
+    },
+    "Your Wi-Fi SSID and password"
+  );

--- a/src/components/esphome-header-menu.ts
+++ b/src/components/esphome-header-menu.ts
@@ -7,6 +7,7 @@ import "@material/mwc-button";
 import type { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import { openEditDialog } from "../legacy";
 import { openUpdateAllDialog } from "../update-all";
+import { SECRETS_FILE } from "../api/secrets";
 
 const isWideListener = window.matchMedia("(min-width: 601px)");
 
@@ -81,7 +82,7 @@ export class ESPHomeHeaderMenu extends LitElement {
   }
 
   private _handleEditSecrets() {
-    openEditDialog("secrets.yaml");
+    openEditDialog(SECRETS_FILE);
   }
 
   private _handleOverflowAction(ev: CustomEvent<ActionDetail>) {

--- a/src/delete-device/delete-device-dialog.ts
+++ b/src/delete-device/delete-device-dialog.ts
@@ -20,14 +20,15 @@ class ESPHomeDeleteDeviceDialog extends LitElement {
         <div>Are you sure you want to delete ${this.name}?</div>
         <mwc-button
           slot="primaryAction"
+          label="Delete"
           dialogAction="close"
           @click=${this._handleDelete}
-        >
-          Delete
-        </mwc-button>
-        <mwc-button slot="secondaryAction" dialogAction="cancel">
-          Cancel
-        </mwc-button>
+        ></mwc-button>
+        <mwc-button
+          slot="secondaryAction"
+          label="Cancel"
+          dialogAction="cancel"
+        ></mwc-button>
       </mwc-dialog>
     `;
   }

--- a/src/devices/importable-device-card.ts
+++ b/src/devices/importable-device-card.ts
@@ -4,6 +4,7 @@ import { ImportableDevice, importDevice } from "../api/devices";
 import "@material/mwc-button";
 import "../components/esphome-card";
 import { fireEvent } from "../util/fire-event";
+import { openAdoptDialog } from "../adopt";
 
 @customElement("esphome-importable-device-card")
 class ESPHomeImportableDeviceCard extends LitElement {
@@ -53,8 +54,7 @@ class ESPHomeImportableDeviceCard extends LitElement {
   `;
 
   private async _handleAdopt() {
-    await importDevice(this.device);
-    fireEvent(this, "adopted");
+    openAdoptDialog(this.device, () => fireEvent(this, "adopted"));
   }
 }
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -25,7 +25,12 @@ import { flashConfiguration } from "../flash";
 import { boardSelectOptions } from "./boards";
 import { subscribeOnlineStatus } from "../api/online-status";
 import { refreshDevices } from "../api/devices";
-import { checkHasWifiSecrets, storeWifiSecrets } from "../api/wifi";
+import {
+  checkHasWifiSecrets,
+  SECRET_WIFI_PASSWORD,
+  SECRET_WIFI_SSID,
+  storeWifiSecrets,
+} from "../api/wifi";
 import { openInstallDialog } from "../install-update";
 
 const OK_ICON = "🎉";
@@ -51,7 +56,10 @@ export class ESPHomeWizardDialog extends LitElement {
 
   private _customBoard = "";
 
-  private _data: Partial<CreateConfigParams> = {};
+  private _data: Partial<CreateConfigParams> = {
+    ssid: `!secret ${SECRET_WIFI_SSID}`,
+    psk: `!secret ${SECRET_WIFI_PASSWORD}`,
+  };
 
   private _wifi?: { ssid: string; password: string };
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -25,6 +25,8 @@ import { flashConfiguration } from "../flash";
 import { boardSelectOptions } from "./boards";
 import { subscribeOnlineStatus } from "../api/online-status";
 import { refreshDevices } from "../api/devices";
+import { checkHasWifiSecrets, storeWifiSecrets } from "../api/wifi";
+import { openInstallDialog } from "../install-update";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
@@ -44,9 +46,14 @@ export class ESPHomeWizardDialog extends LitElement {
 
   @state() private _board: "ESP32" | "ESP8266" | "CUSTOM" = "ESP32";
 
+  // undefined = not loaded
+  @state() private _hasWifiSecrets: undefined | boolean = undefined;
+
   private _customBoard = "";
 
   private _data: Partial<CreateConfigParams> = {};
+
+  private _wifi?: { ssid: string; password: string };
 
   @state() private _writeProgress = 0;
 
@@ -72,8 +79,7 @@ export class ESPHomeWizardDialog extends LitElement {
     let hideActions = false;
 
     if (this._state === "basic_config") {
-      heading = "Create configuration";
-      content = this._renderBasicConfig();
+      [heading, content, hideActions] = this._renderBasicConfig();
     } else if (this._state === "pick_board") {
       heading = "Select your ESP device";
       content = this._renderPickBoard();
@@ -102,11 +108,7 @@ export class ESPHomeWizardDialog extends LitElement {
       content = this._renderProgress("Finding device on network");
       hideActions = true;
     } else if (this._state === "done") {
-      if (this._error) {
-        content = this._renderMessage(WARNING_ICON, this._error, true);
-      } else {
-        content = this._renderMessage(OK_ICON, `Configuration created!`, true);
-      }
+      content = this._renderDone();
     }
 
     return html`
@@ -157,8 +159,13 @@ export class ESPHomeWizardDialog extends LitElement {
     `;
   }
 
-  private _renderBasicConfig() {
-    return html`
+  private _renderBasicConfig(): [string | undefined, TemplateResult, boolean] {
+    if (this._hasWifiSecrets === undefined) {
+      return [undefined, this._renderProgress("Initializing"), true];
+    }
+    const heading = "Create configuration";
+    let hideActions = false;
+    const content = html`
       ${supportsWebSerial
         ? ""
         : html`
@@ -188,24 +195,38 @@ export class ESPHomeWizardDialog extends LitElement {
         @blur=${this._cleanNameBlur}
       ></mwc-textfield>
 
-      <div>
-        Enter your Wi-Fi information so your device can connect to your wireless
-        network.
-      </div>
+      ${this._hasWifiSecrets
+        ? html`
+            <div>
+              This device will be configured to connect to the Wi-Fi network
+              stored in your secrets.
+            </div>
+          `
+        : html`
+            <div>
+              Enter the credentials of the Wi-Fi network that you want your
+              device to connect to.
+            </div>
+            <div>
+              This information will be stored in your secrets and used for this
+              and future devices. You can edit the information later by editing
+              your secrets at the top of the page.
+            </div>
 
-      <mwc-textfield
-        label="Wi-Fi SSID"
-        name="ssid"
-        required
-        @blur=${this._cleanSSIDBlur}
-      ></mwc-textfield>
+            <mwc-textfield
+              label="Network name"
+              name="ssid"
+              required
+              @blur=${this._cleanSSIDBlur}
+            ></mwc-textfield>
 
-      <mwc-textfield
-        label="Wi-Fi password"
-        name="password"
-        type="password"
-        helper="Leave blank if no password"
-      ></mwc-textfield>
+            <mwc-textfield
+              label="Password"
+              name="password"
+              type="password"
+              helper="Leave blank if no password"
+            ></mwc-textfield>
+          `}
 
       <mwc-button
         slot="primaryAction"
@@ -220,6 +241,8 @@ export class ESPHomeWizardDialog extends LitElement {
         label="Cancel"
       ></mwc-button>
     `;
+
+    return [heading, content, hideActions];
   }
 
   private _renderPickBoard() {
@@ -321,8 +344,43 @@ export class ESPHomeWizardDialog extends LitElement {
     `;
   }
 
+  private _renderDone() {
+    if (this._error) {
+      return this._renderMessage(WARNING_ICON, this._error, true);
+    }
+    return html`
+      <div class="center">
+        <div class="icon">${OK_ICON}</div>
+        Configuration created!
+      </div>
+
+      ${
+        // Users that have webserial got offered the installation step
+        supportsWebSerial
+          ? html`
+              <mwc-button
+                slot="primaryAction"
+                dialogAction="ok"
+                label="Close"
+              ></mwc-button>
+            `
+          : html`
+              <mwc-button
+                slot="primaryAction"
+                dialogAction="ok"
+                label="Install"
+                @click=${() => openInstallDialog(this._data.name!)}
+              ></mwc-button>
+            `
+      }
+    `;
+  }
+
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
+    checkHasWifiSecrets().then((hasWifiSecrets) => {
+      this._hasWifiSecrets = hasWifiSecrets;
+    });
   }
 
   protected updated(changedProps: PropertyValues) {
@@ -367,16 +425,17 @@ export class ESPHomeWizardDialog extends LitElement {
 
   private async _handleBasicConfigSubmit() {
     const nameInput = this._inputName;
-    const ssidInput = this._inputSSID;
 
     const nameValid = nameInput.reportValidity();
-    const ssidValid = ssidInput.reportValidity();
+    const ssidValid = this._hasWifiSecrets
+      ? true
+      : this._inputSSID.reportValidity();
 
     if (!nameValid || !ssidValid) {
       if (!nameValid) {
         nameInput.focus();
       } else {
-        ssidInput.focus();
+        this._inputSSID.focus();
       }
       return;
     }
@@ -392,8 +451,13 @@ export class ESPHomeWizardDialog extends LitElement {
     }
 
     this._data.name = name;
-    this._data.ssid = ssidInput.value;
-    this._data.psk = this._inputPassword.value;
+
+    if (!this._hasWifiSecrets) {
+      this._wifi = {
+        ssid: this._inputSSID.value,
+        password: this._inputPassword.value,
+      };
+    }
 
     // Use set timeout to avoid dialog keydown handler pressing next button too
     setTimeout(() => {
@@ -426,6 +490,9 @@ export class ESPHomeWizardDialog extends LitElement {
     this._busy = true;
 
     try {
+      if (this._wifi) {
+        await storeWifiSecrets(this._wifi.ssid, this._wifi.password);
+      }
       await createConfiguration(this._data as CreateConfigParams);
       refreshDevices();
       this._state = "done";
@@ -449,10 +516,11 @@ export class ESPHomeWizardDialog extends LitElement {
     try {
       try {
         esploader = await connect(console);
-      } catch (err) {
+      } catch (err: any) {
         console.error(err);
-        // User pressed enter.
-        this._error = "Press skip step if you don't want to install it now.";
+        if ((err as DOMException).name !== "NotFoundError") {
+          this._error = err.message || String(err);
+        }
         return;
       }
 


### PR DESCRIPTION
We want users to use secrets for storing their Wi-Fi username and password. This changes the workflow for adding a new configuration and adopting a device to use secrets.

If we detect that you don't have secrets for your Wi-Fi, we will ask you and store it in your secrets file (appended to end of the file)

If we detect Wi-Fi secrets we will notify the user that the secrets are being used.

The secret name is not configurable. It's set to be the same as the configuration keys (`wifi_ssid`, `wifi_password`).

Requires https://github.com/esphome/esphome/pull/2873, https://github.com/esphome/esphome/pull/2874 and https://github.com/esphome/esphome/pull/2875

# Wizard updates

## Wizard if Wi-Fi info stored in secrets

![image](https://user-images.githubusercontent.com/1444314/144803014-623beda2-0789-489a-9759-82b2d6967073.png)

## Wizard if Wi-Fi info not stored in secrets

![image](https://user-images.githubusercontent.com/1444314/144803044-6d249956-e48f-4b4e-a705-e94134559f57.png)

## Wizard finishing prompts installation if no web serial was detected

![image](https://user-images.githubusercontent.com/1444314/144803203-2472effb-a7c5-4d5a-9b2a-86839abc0ab9.png)


# Adoption updates

It is now changed to a confirmation dialog.

## First time adopting a device if no secrets defined:

![image](https://user-images.githubusercontent.com/1444314/144802838-fbe39160-c683-4c3b-b139-d502520ba94f.png)

## Adopting success now offers installation that opens the normal install menu

![image](https://user-images.githubusercontent.com/1444314/144802875-0419809e-ce41-4691-bf7c-f282b25c1a0d.png)

## Adoption confirmation when secrets are configured

![image](https://user-images.githubusercontent.com/1444314/144802929-db626b6c-3d1e-4ae5-9703-e81f5a4a3ad0.png)
