### PR TITLE
Allow showing logs over webserial

### DIFF
--- a/src/components/remote-process.ts
+++ b/src/components/remote-process.ts
@@ -1,6 +1,6 @@
 import { customElement } from "lit/decorators.js";
 import { StreamError, streamLogs } from "../api";
-import { ColoredConsole } from "../util/console-color";
+import { ColoredConsole, coloredConsoleStyles } from "../util/console-color";
 import { fireEvent } from "../util/fire-event";
 
 @customElement("esphome-remote-process")
@@ -19,97 +19,7 @@ class ESPHomeRemoteProcess extends HTMLElement {
     const shadowRoot = this.attachShadow({ mode: "open" });
 
     shadowRoot.innerHTML = `
-      <style>
-        .log {
-          height: var(--remote-process-height, 100%);
-          background-color: #1c1c1c;
-          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
-            monospace;
-          font-size: 12px;
-          padding: 16px;
-          overflow: auto;
-          line-height: 1.45;
-          border-radius: 3px;
-          white-space: pre-wrap;
-          overflow-wrap: break-word;
-          color: #ddd;
-        }
-
-        .log-bold {
-          font-weight: bold;
-        }
-        .log-italic {
-          font-style: italic;
-        }
-        .log-underline {
-          text-decoration: underline;
-        }
-        .log-strikethrough {
-          text-decoration: line-through;
-        }
-        .log-underline.log-strikethrough {
-          text-decoration: underline line-through;
-        }
-        .log-secret {
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;
-        }
-        .log-secret-redacted {
-          opacity: 0;
-          width: 1px;
-          font-size: 1px;
-        }
-        .log-fg-black {
-          color: rgb(128, 128, 128);
-        }
-        .log-fg-red {
-          color: rgb(255, 0, 0);
-        }
-        .log-fg-green {
-          color: rgb(0, 255, 0);
-        }
-        .log-fg-yellow {
-          color: rgb(255, 255, 0);
-        }
-        .log-fg-blue {
-          color: rgb(0, 0, 255);
-        }
-        .log-fg-magenta {
-          color: rgb(255, 0, 255);
-        }
-        .log-fg-cyan {
-          color: rgb(0, 255, 255);
-        }
-        .log-fg-white {
-          color: rgb(187, 187, 187);
-        }
-        .log-bg-black {
-          background-color: rgb(0, 0, 0);
-        }
-        .log-bg-red {
-          background-color: rgb(255, 0, 0);
-        }
-        .log-bg-green {
-          background-color: rgb(0, 255, 0);
-        }
-        .log-bg-yellow {
-          background-color: rgb(255, 255, 0);
-        }
-        .log-bg-blue {
-          background-color: rgb(0, 0, 255);
-        }
-        .log-bg-magenta {
-          background-color: rgb(255, 0, 255);
-        }
-        .log-bg-cyan {
-          background-color: rgb(0, 255, 255);
-        }
-        .log-bg-white {
-          background-color: rgb(255, 255, 255);
-        }
-      </style>
+      <style>${coloredConsoleStyles}</style>
       <div class="log"></div>
     `;
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -15,3 +15,15 @@ export const metaChevronRight = svg`
     <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z" />
   </svg>
 `;
+
+export const metaHelp = svg`
+  <svg width="24" height="24" viewBox="0 0 24 24" slot="meta">
+    <path d="M11,18H13V16H11V18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,6A4,4 0 0,0 8,10H10A2,2 0 0,1 12,8A2,2 0 0,1 14,10C14,12 11,11.75 11,15H13C13,12.75 16,12.5 16,10A4,4 0 0,0 12,6Z" />
+  </svg>
+`;
+
+export interface Logger {
+  log(msg: string, ...args: any[]): void;
+  error(msg: string, ...args: any[]): void;
+  debug(msg: string, ...args: any[]): void;
+}

--- a/src/install-update/install-dialog.ts
+++ b/src/install-update/install-dialog.ts
@@ -1,14 +1,7 @@
 // On pick and it's OTA or serial on host
 // Then set window.SELECTED_UPLOAD_PORT to a string.
 
-import {
-  LitElement,
-  html,
-  PropertyValues,
-  css,
-  svg,
-  TemplateResult,
-} from "lit";
+import { LitElement, html, PropertyValues, css, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { getSerialPorts, SerialPort } from "../api/serial-ports";
 import "@material/mwc-dialog";
@@ -16,7 +9,12 @@ import "@material/mwc-list/mwc-list-item.js";
 import "@material/mwc-circular-progress";
 import "@material/mwc-button";
 import { connect, ESPLoader } from "esp-web-flasher";
-import { allowsWebSerial, metaChevronRight, supportsWebSerial } from "../const";
+import {
+  allowsWebSerial,
+  metaChevronRight,
+  metaHelp,
+  supportsWebSerial,
+} from "../const";
 import {
   compileConfiguration,
   Configuration,
@@ -28,12 +26,6 @@ import { openCompileDialog } from "../compile";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
-
-const metaHelp = svg`
-  <svg width="24" height="24" viewBox="0 0 24 24" slot="meta">
-    <path d="M11,18H13V16H11V18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,6A4,4 0 0,0 8,10H10A2,2 0 0,1 12,8A2,2 0 0,1 14,10C14,12 11,11.75 11,15H13C13,12.75 16,12.5 16,10A4,4 0 0,0 12,6Z" />
-  </svg>
-`;
 
 @customElement("esphome-install-dialog")
 class ESPHomeInstallDialog extends LitElement {

--- a/src/logs-target/logs-target-dialog.ts
+++ b/src/logs-target/logs-target-dialog.ts
@@ -7,7 +7,13 @@ import "../components/remote-process";
 import "../components/process-dialog";
 import { openLogsDialog } from "../logs";
 import { getSerialPorts, SerialPort } from "../api/serial-ports";
-import { metaChevronRight } from "../const";
+import {
+  allowsWebSerial,
+  metaChevronRight,
+  metaHelp,
+  supportsWebSerial,
+} from "../const";
+import { openLogsWebSerialDialog } from "../logs-webserial";
 
 @customElement("esphome-logs-target-dialog")
 class ESPHomeLogsTargetDialog extends LitElement {
@@ -15,45 +21,84 @@ class ESPHomeLogsTargetDialog extends LitElement {
 
   @state() private _ports?: SerialPort[];
 
-  protected render() {
-    if (!this._ports) {
-      return html``;
-    }
+  @state() private _show: "options" | "server_ports" = "options";
 
+  protected render() {
     return html`
       <mwc-dialog
         open
-        heading=${"Show Logs"}
+        heading=${this._show === "options"
+          ? "How to get the logs for your ESP device?"
+          : "Pick server port"}
         scrimClickAction
         @closed=${this._handleClose}
       >
-        <mwc-list-item
-          twoline
-          hasMeta
-          dialogAction="close"
-          .port=${"OTA"}
-          @click=${this._pickPort}
-        >
-          <span>Connect wirelessly</span>
-          <span slot="secondary">Requires the device to be online</span>
-          ${metaChevronRight}
-        </mwc-list-item>
+        ${this._show === "options"
+          ? html`
+              <mwc-list-item
+                twoline
+                hasMeta
+                dialogAction="close"
+                .port=${"OTA"}
+                @click=${this._pickPort}
+              >
+                <span>Wirelessly</span>
+                <span slot="secondary">Requires the device to be online</span>
+                ${metaChevronRight}
+              </mwc-list-item>
 
-        ${this._ports.map(
-          (port) => html`
-            <mwc-list-item
-              twoline
-              hasMeta
-              dialogAction="close"
-              .port=${port.port}
-              @click=${this._pickPort}
-            >
-              <span>${port.desc}</span>
-              <span slot="secondary">${port.port}</span>
-              ${metaChevronRight}
-            </mwc-list-item>
-          `
-        )}
+              <mwc-list-item
+                twoline
+                hasMeta
+                .port=${"WEBSERIAL"}
+                @click=${this._pickWebSerial}
+              >
+                <span>Plug into this computer</span>
+                <span slot="secondary">
+                  ${supportsWebSerial
+                    ? "For devices connected via USB to this computer"
+                    : allowsWebSerial
+                    ? "Your browser is not supported"
+                    : "Dashboard needs to opened via HTTPS"}
+                </span>
+                ${supportsWebSerial ? metaChevronRight : metaHelp}
+              </mwc-list-item>
+
+              <mwc-list-item twoline hasMeta @click=${this._showServerPorts}>
+                <span>Plug into the computer running ESPHome Dashboard</span>
+                <span slot="secondary">
+                  For devices connected via USB to the server
+                </span>
+                ${metaChevronRight}
+              </mwc-list-item>
+            `
+          : this._ports === undefined
+          ? html`
+              <mwc-list-item>
+                <span>Loading ports…</span>
+              </mwc-list-item>
+            `
+          : this._ports.length === 0
+          ? html`
+              <mwc-list-item>
+                <span>No serial ports found.</span>
+              </mwc-list-item>
+            `
+          : this._ports.map(
+              (port) => html`
+                <mwc-list-item
+                  twoline
+                  hasMeta
+                  dialogAction="close"
+                  .port=${port.port}
+                  @click=${this._pickPort}
+                >
+                  <span>${port.desc}</span>
+                  <span slot="secondary">${port.port}</span>
+                  ${metaChevronRight}
+                </mwc-list-item>
+              `
+            )}
 
         <mwc-button
           no-attention
@@ -65,11 +110,11 @@ class ESPHomeLogsTargetDialog extends LitElement {
     `;
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
-    super.firstUpdated(changedProps);
+  protected firstUpdated(changedProperties: PropertyValues) {
+    super.firstUpdated(changedProperties);
     getSerialPorts().then((ports) => {
-      if (ports.length === 0) {
-        // Automatically pick wireless option if no ports are found
+      if (ports.length === 0 && !supportsWebSerial) {
+        // Automatically pick wireless option if no other options available
         this._handleClose();
         openLogsDialog(this.configuration, "OTA");
       } else {
@@ -78,8 +123,31 @@ class ESPHomeLogsTargetDialog extends LitElement {
     });
   }
 
+  private _showServerPorts() {
+    this._show = "server_ports";
+  }
+
   private _pickPort(ev: Event) {
     openLogsDialog(this.configuration, (ev.currentTarget as any).port);
+  }
+
+  private async _pickWebSerial(ev: Event) {
+    if (!supportsWebSerial || !allowsWebSerial) {
+      window.open(
+        "https://esphome.io/guides/getting_started_hassio.html#webserial",
+        "_blank"
+      );
+      return;
+    }
+
+    try {
+      const port = await navigator.serial.requestPort();
+      await port.open({ baudRate: 115200 });
+      this.shadowRoot!.querySelector("mwc-dialog")!.close();
+      openLogsWebSerialDialog(this.configuration, port);
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   private _handleClose() {

--- a/src/logs-webserial/ewt-console.ts
+++ b/src/logs-webserial/ewt-console.ts
@@ -1,4 +1,4 @@
-import { ColoredConsole } from "../util/console-color";
+import { ColoredConsole, coloredConsoleStyles } from "../util/console-color";
 import { sleep } from "../util/sleep";
 import { LineBreakTransformer } from "../util/line-break-transformer";
 import { Logger } from "../const";
@@ -26,90 +26,6 @@ export class EwtConsole extends HTMLElement {
             monospace;
           line-height: 1.45;
         }
-        .log {
-          box-sizing: border-box;
-          height: calc(100% - 28px);
-          font-size: 12px;
-          padding: 16px;
-          overflow: auto;
-          white-space: pre-wrap;
-          overflow-wrap: break-word;
-        }
-
-        .log-bold {
-          font-weight: bold;
-        }
-        .log-italic {
-          font-style: italic;
-        }
-        .log-underline {
-          text-decoration: underline;
-        }
-        .log-strikethrough {
-          text-decoration: line-through;
-        }
-        .log-underline.log-strikethrough {
-          text-decoration: underline line-through;
-        }
-        .log-secret {
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;
-        }
-        .log-secret-redacted {
-          opacity: 0;
-          width: 1px;
-          font-size: 1px;
-        }
-        .log-fg-black {
-          color: rgb(128, 128, 128);
-        }
-        .log-fg-red {
-          color: rgb(255, 0, 0);
-        }
-        .log-fg-green {
-          color: rgb(0, 255, 0);
-        }
-        .log-fg-yellow {
-          color: rgb(255, 255, 0);
-        }
-        .log-fg-blue {
-          color: rgb(0, 0, 255);
-        }
-        .log-fg-magenta {
-          color: rgb(255, 0, 255);
-        }
-        .log-fg-cyan {
-          color: rgb(0, 255, 255);
-        }
-        .log-fg-white {
-          color: rgb(187, 187, 187);
-        }
-        .log-bg-black {
-          background-color: rgb(0, 0, 0);
-        }
-        .log-bg-red {
-          background-color: rgb(255, 0, 0);
-        }
-        .log-bg-green {
-          background-color: rgb(0, 255, 0);
-        }
-        .log-bg-yellow {
-          background-color: rgb(255, 255, 0);
-        }
-        .log-bg-blue {
-          background-color: rgb(0, 0, 255);
-        }
-        .log-bg-magenta {
-          background-color: rgb(255, 0, 255);
-        }
-        .log-bg-cyan {
-          background-color: rgb(0, 255, 255);
-        }
-        .log-bg-white {
-          background-color: rgb(255, 255, 255);
-        }
         form {
           display: flex;
           align-items: center;
@@ -122,6 +38,7 @@ export class EwtConsole extends HTMLElement {
           border: 0;
           outline: none;
         }
+        ${coloredConsoleStyles}
       </style>
       <div class="log"></div>
       ${

--- a/src/logs-webserial/ewt-console.ts
+++ b/src/logs-webserial/ewt-console.ts
@@ -1,0 +1,240 @@
+import { ColoredConsole } from "../util/console-color";
+import { sleep } from "../util/sleep";
+import { LineBreakTransformer } from "../util/line-break-transformer";
+import { Logger } from "../const";
+
+export class EwtConsole extends HTMLElement {
+  public port!: SerialPort;
+  public logger!: Logger;
+  public allowInput = true;
+
+  private _console?: ColoredConsole;
+  private _cancelConnection?: () => Promise<void>;
+
+  public connectedCallback() {
+    if (this._console) {
+      return;
+    }
+    const shadowRoot = this.attachShadow({ mode: "open" });
+
+    shadowRoot.innerHTML = `
+      <style>
+        :host, input {
+          background-color: #1c1c1c;
+          color: #ddd;
+          font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
+            monospace;
+          line-height: 1.45;
+        }
+        .log {
+          box-sizing: border-box;
+          height: calc(100% - 28px);
+          font-size: 12px;
+          padding: 16px;
+          overflow: auto;
+          white-space: pre-wrap;
+          overflow-wrap: break-word;
+        }
+
+        .log-bold {
+          font-weight: bold;
+        }
+        .log-italic {
+          font-style: italic;
+        }
+        .log-underline {
+          text-decoration: underline;
+        }
+        .log-strikethrough {
+          text-decoration: line-through;
+        }
+        .log-underline.log-strikethrough {
+          text-decoration: underline line-through;
+        }
+        .log-secret {
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          -ms-user-select: none;
+          user-select: none;
+        }
+        .log-secret-redacted {
+          opacity: 0;
+          width: 1px;
+          font-size: 1px;
+        }
+        .log-fg-black {
+          color: rgb(128, 128, 128);
+        }
+        .log-fg-red {
+          color: rgb(255, 0, 0);
+        }
+        .log-fg-green {
+          color: rgb(0, 255, 0);
+        }
+        .log-fg-yellow {
+          color: rgb(255, 255, 0);
+        }
+        .log-fg-blue {
+          color: rgb(0, 0, 255);
+        }
+        .log-fg-magenta {
+          color: rgb(255, 0, 255);
+        }
+        .log-fg-cyan {
+          color: rgb(0, 255, 255);
+        }
+        .log-fg-white {
+          color: rgb(187, 187, 187);
+        }
+        .log-bg-black {
+          background-color: rgb(0, 0, 0);
+        }
+        .log-bg-red {
+          background-color: rgb(255, 0, 0);
+        }
+        .log-bg-green {
+          background-color: rgb(0, 255, 0);
+        }
+        .log-bg-yellow {
+          background-color: rgb(255, 255, 0);
+        }
+        .log-bg-blue {
+          background-color: rgb(0, 0, 255);
+        }
+        .log-bg-magenta {
+          background-color: rgb(255, 0, 255);
+        }
+        .log-bg-cyan {
+          background-color: rgb(0, 255, 255);
+        }
+        .log-bg-white {
+          background-color: rgb(255, 255, 255);
+        }
+        form {
+          display: flex;
+          align-items: center;
+          padding: 0 8px 0 16px;
+        }
+        input {
+          flex: 1;
+          padding: 4px;
+          margin: 0 8px;
+          border: 0;
+          outline: none;
+        }
+      </style>
+      <div class="log"></div>
+      ${
+        this.allowInput
+          ? `<form>
+                >
+                <input autofocus>
+              </form>
+            `
+          : ""
+      }
+    `;
+
+    this._console = new ColoredConsole(this.shadowRoot!.querySelector("div")!);
+
+    if (this.allowInput) {
+      const input = this.shadowRoot!.querySelector("input")!;
+
+      this.addEventListener("click", () => {
+        // Only focus input if user didn't select some text
+        if (getSelection()?.toString() === "") {
+          input.focus();
+        }
+      });
+
+      input.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter") {
+          ev.preventDefault();
+          ev.stopPropagation();
+          this._sendCommand();
+        }
+      });
+    }
+
+    const abortController = new AbortController();
+    const connection = this._connect(abortController.signal);
+    this._cancelConnection = () => {
+      abortController.abort();
+      return connection;
+    };
+  }
+
+  private async _connect(abortSignal: AbortSignal) {
+    this.logger.debug("Starting console read loop");
+    try {
+      await this.port
+        .readable!.pipeThrough(new TextDecoderStream(), {
+          signal: abortSignal,
+        })
+        .pipeThrough(new TransformStream(new LineBreakTransformer()))
+        .pipeTo(
+          new WritableStream({
+            write: (chunk) => {
+              this._console!.addLine(chunk.replace("\r", ""));
+            },
+          })
+        );
+      if (!abortSignal.aborted) {
+        this._console!.addLine("");
+        this._console!.addLine("");
+        this._console!.addLine("Terminal disconnected");
+      }
+    } catch (e) {
+      this._console!.addLine("");
+      this._console!.addLine("");
+      this._console!.addLine(`Terminal disconnected: ${e}`);
+    } finally {
+      await sleep(100);
+      this.logger.debug("Finished console read loop");
+    }
+  }
+
+  private async _sendCommand() {
+    const input = this.shadowRoot!.querySelector("input")!;
+    const command = input.value;
+    const encoder = new TextEncoder();
+    const writer = this.port.writable!.getWriter();
+    await writer.write(encoder.encode(command + "\r\n"));
+    this._console!.addLine(`> ${command}\r\n`);
+    input.value = "";
+    input.focus();
+    try {
+      writer.releaseLock();
+    } catch (err) {
+      console.error("Ignoring release lock error", err);
+    }
+  }
+
+  public async disconnect() {
+    if (this._cancelConnection) {
+      await this._cancelConnection();
+      this._cancelConnection = undefined;
+    }
+  }
+
+  public async reset() {
+    this.logger.debug("Triggering reset.");
+    await this.port.setSignals({
+      dataTerminalReady: false,
+      requestToSend: true,
+    });
+    await this.port.setSignals({
+      dataTerminalReady: false,
+      requestToSend: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+}
+
+customElements.define("ewt-console", EwtConsole);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ewt-console": EwtConsole;
+  }
+}

--- a/src/logs-webserial/index.ts
+++ b/src/logs-webserial/index.ts
@@ -1,0 +1,12 @@
+const preload = () => import("./logs-webserial-dialog");
+
+export const openLogsWebSerialDialog = (
+  configuration: string,
+  port: SerialPort
+) => {
+  preload();
+  const dialog = document.createElement("esphome-logs-webserial-dialog");
+  dialog.configuration = configuration;
+  dialog.port = port;
+  document.body.append(dialog);
+};

--- a/src/logs-webserial/logs-webserial-dialog.ts
+++ b/src/logs-webserial/logs-webserial-dialog.ts
@@ -1,0 +1,79 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import "@material/mwc-button";
+import "@material/mwc-list/mwc-list-item.js";
+import "../components/remote-process";
+import { openEditDialog } from "../legacy";
+import "../components/process-dialog";
+import "./ewt-console";
+
+@customElement("esphome-logs-webserial-dialog")
+class ESPHomeLogsWebSerialDialog extends LitElement {
+  @property() public configuration!: string;
+
+  @property() public port!: SerialPort;
+
+  protected render() {
+    return html`
+      <mwc-dialog
+        open
+        .heading=${`Logs ${this.configuration}`}
+        scrimClickAction
+        @closed=${this._handleClose}
+      >
+        <ewt-console
+          .port=${this.port}
+          .logger=${console}
+          .allowInput=${false}
+        ></ewt-console>
+        <mwc-button
+          slot="secondaryAction"
+          dialogAction="close"
+          label="Edit"
+          @click=${this._openEdit}
+        ></mwc-button>
+        <mwc-button
+          slot="secondaryAction"
+          label="Reset Device"
+          @click=${this._resetDevice}
+        ></mwc-button>
+        <mwc-button
+          slot="primaryAction"
+          dialogAction="close"
+          label="Close"
+        ></mwc-button>
+      </mwc-dialog>
+    `;
+  }
+
+  private _openEdit() {
+    openEditDialog(this.configuration);
+  }
+
+  private async _handleClose() {
+    await this.shadowRoot!.querySelector("ewt-console")!.disconnect();
+    await this.port.close();
+    this.parentNode!.removeChild(this);
+  }
+
+  private async _resetDevice() {
+    await this.shadowRoot!.querySelector("ewt-console")!.reset();
+  }
+
+  static styles = css`
+    mwc-dialog {
+      --mdc-dialog-max-width: 90vw;
+    }
+    ewt-console {
+      display: block;
+      width: calc(80vw - 48px);
+      height: 80vh;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-logs-webserial-dialog": ESPHomeLogsWebSerialDialog;
+  }
+}

--- a/src/util/console-color.ts
+++ b/src/util/console-color.ts
@@ -185,3 +185,95 @@ export class ColoredConsole {
     }
   }
 }
+
+export const coloredConsoleStyles = `
+  .log {
+    height: var(--remote-process-height, 100%);
+    background-color: #1c1c1c;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
+      monospace;
+    font-size: 12px;
+    padding: 16px;
+    overflow: auto;
+    line-height: 1.45;
+    border-radius: 3px;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    color: #ddd;
+  }
+
+  .log-bold {
+    font-weight: bold;
+  }
+  .log-italic {
+    font-style: italic;
+  }
+  .log-underline {
+    text-decoration: underline;
+  }
+  .log-strikethrough {
+    text-decoration: line-through;
+  }
+  .log-underline.log-strikethrough {
+    text-decoration: underline line-through;
+  }
+  .log-secret {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+  .log-secret-redacted {
+    opacity: 0;
+    width: 1px;
+    font-size: 1px;
+  }
+  .log-fg-black {
+    color: rgb(128, 128, 128);
+  }
+  .log-fg-red {
+    color: rgb(255, 0, 0);
+  }
+  .log-fg-green {
+    color: rgb(0, 255, 0);
+  }
+  .log-fg-yellow {
+    color: rgb(255, 255, 0);
+  }
+  .log-fg-blue {
+    color: rgb(0, 0, 255);
+  }
+  .log-fg-magenta {
+    color: rgb(255, 0, 255);
+  }
+  .log-fg-cyan {
+    color: rgb(0, 255, 255);
+  }
+  .log-fg-white {
+    color: rgb(187, 187, 187);
+  }
+  .log-bg-black {
+    background-color: rgb(0, 0, 0);
+  }
+  .log-bg-red {
+    background-color: rgb(255, 0, 0);
+  }
+  .log-bg-green {
+    background-color: rgb(0, 255, 0);
+  }
+  .log-bg-yellow {
+    background-color: rgb(255, 255, 0);
+  }
+  .log-bg-blue {
+    background-color: rgb(0, 0, 255);
+  }
+  .log-bg-magenta {
+    background-color: rgb(255, 0, 255);
+  }
+  .log-bg-cyan {
+    background-color: rgb(0, 255, 255);
+  }
+  .log-bg-white {
+    background-color: rgb(255, 255, 255);
+  }
+`;

--- a/src/util/line-break-transformer.ts
+++ b/src/util/line-break-transformer.ts
@@ -1,0 +1,20 @@
+export class LineBreakTransformer implements Transformer<string, string> {
+  private chunks = "";
+
+  transform(
+    chunk: string,
+    controller: TransformStreamDefaultController<string>
+  ) {
+    // Append new chunks to existing chunks.
+    this.chunks += chunk;
+    // For each line breaks in chunks, send the parsed lines out.
+    const lines = this.chunks.split("\r\n");
+    this.chunks = lines.pop()!;
+    lines.forEach((line) => controller.enqueue(line + "\r\n"));
+  }
+
+  flush(controller: TransformStreamDefaultController<string>) {
+    // When the stream is closed, flush any remaining chunks out.
+    controller.enqueue(this.chunks);
+  }
+}

--- a/src/util/sleep.ts
+++ b/src/util/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (time: number) =>
+  new Promise((resolve) => setTimeout(resolve, time));


### PR DESCRIPTION
Pick logs target now has a webserial option.

For it to automatically pick OTA also webserial should not be available.

WebSerial dialog also has a "reset device" option so you can observe the initial boot.

![image](https://user-images.githubusercontent.com/1444314/145530853-fc9a4d47-40d1-4dd8-8372-e37b22a2d32e.png)

![CleanShot 2021-12-09 at 22 57 08](https://user-images.githubusercontent.com/1444314/145531044-c34432fd-3f5e-4284-b965-6aa2dff82a32.png)

