### PR TITLE
Allow skipping installation when web serial not available

### DIFF
--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -343,7 +343,6 @@ export class ESPHomeWizardDialog extends LitElement {
         @click=${this._handleConnectSerialSubmit}
       ></mwc-button>
       <mwc-button
-        no-attention
         slot="secondaryAction"
         label="Skip this step"
         .disabled=${this._busy}
@@ -373,6 +372,11 @@ export class ESPHomeWizardDialog extends LitElement {
               ></mwc-button>
             `
           : html`
+              <mwc-button
+                slot="secondaryAction"
+                dialogAction="close"
+                label="Skip"
+              ></mwc-button>
               <mwc-button
                 slot="primaryAction"
                 dialogAction="ok"
@@ -716,7 +720,8 @@ export class ESPHomeWizardDialog extends LitElement {
       text-decoration: underline;
       cursor: pointer;
     }
-    mwc-button[no-attention] {
+
+    mwc-button[slot="secondaryAction"] {
       --mdc-theme-primary: #444;
       --mdc-theme-on-primary: white;
     }

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -358,33 +358,27 @@ export class ESPHomeWizardDialog extends LitElement {
     return html`
       <div class="center">
         <div class="icon">${OK_ICON}</div>
-        Configuration created!
+        <b>Configuration created!</b>
       </div>
-
-      ${
-        // Users that have webserial got offered the installation step
-        supportsWebSerial
-          ? html`
-              <mwc-button
-                slot="primaryAction"
-                dialogAction="ok"
-                label="Close"
-              ></mwc-button>
-            `
-          : html`
-              <mwc-button
-                slot="secondaryAction"
-                dialogAction="close"
-                label="Skip"
-              ></mwc-button>
-              <mwc-button
-                slot="primaryAction"
-                dialogAction="ok"
-                label="Install"
-                @click=${() => openInstallDialog(this._data.name!)}
-              ></mwc-button>
-            `
-      }
+      <div>
+        You can now install the configuration to your device. The first time
+        this requires a cable.
+      </div>
+      <div>
+        Once the device is installed and connected to your network, you will be
+        able to manage it wirelessly.
+      </div>
+      <mwc-button
+        slot="secondaryAction"
+        dialogAction="close"
+        label="Skip"
+      ></mwc-button>
+      <mwc-button
+        slot="primaryAction"
+        dialogAction="ok"
+        label="Install"
+        @click=${() => openInstallDialog(`${this._data.name!}.yaml`)}
+      ></mwc-button>
     `;
   }
 


### PR DESCRIPTION
Allow skipping the installation at the end of the wizard when web serial is not available. Also explain why a user should install.

![image](https://user-images.githubusercontent.com/1444314/147504009-3e8cd6c4-037c-4456-a644-6c14b6895e0f.png)

