### PR TITLE
Remove extra top padding on fab

### DIFF
--- a/src/components/esphome-fab.ts
+++ b/src/components/esphome-fab.ts
@@ -25,8 +25,6 @@ export class ESPHomeFab extends LitElement {
       position: fixed;
       right: 23px;
       bottom: 23px;
-      padding-top: 15px;
-      margin-bottom: 0;
       z-index: 997;
       --mdc-theme-secondary: var(--alert-success-color);
     }


### PR DESCRIPTION
There was unnecessary extra top padding on the "Add device" fab, causing it to capture clicks meant for the overflow menu of a device card.

CC @frenck 