### PR TITLE
Make install-web dialog reusable

### DIFF
--- a/src/devices/importable-device-card.ts
+++ b/src/devices/importable-device-card.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ImportableDevice, importDevice } from "../api/devices";
+import { ImportableDevice } from "../api/devices";
 import "@material/mwc-button";
 import "../components/esphome-card";
 import { fireEvent } from "../util/fire-event";

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -15,7 +15,6 @@ import {
 import { openInstallServerDialog } from "../install-server";
 import { openCompileDialog } from "../compile";
 import { openInstallWebDialog } from "../install-web";
-import { connect, ESPLoader } from "esp-web-flasher";
 
 const WARNING_ICON = "👀";
 
@@ -225,16 +224,9 @@ class ESPHomeInstallChooseDialog extends LitElement {
       return;
     }
 
-    let esploader: ESPLoader;
-    try {
-      esploader = await connect(console);
-    } catch (err) {
-      // User aborted
-      return;
+    if (await openInstallWebDialog({ configuration: this.configuration })) {
+      this._close();
     }
-
-    openInstallWebDialog(this.configuration, esploader);
-    this._close();
   }
 
   private _close() {

--- a/src/install-web/index.ts
+++ b/src/install-web/index.ts
@@ -1,14 +1,31 @@
-import type { ESPLoader } from "esp-web-flasher";
+import { connect, ESPLoader } from "esp-web-flasher";
+import type { ESPHomeInstallWebDialog } from "./install-web-dialog";
 
 const preload = () => import("./install-web-dialog");
 
-export const openInstallWebDialog = (
-  configuration: string,
-  esploader: ESPLoader
-) => {
+export const openInstallWebDialog = async (
+  params: ESPHomeInstallWebDialog["params"]
+): Promise<boolean> => {
   preload();
+
+  let esploader: ESPLoader;
+
+  if (params.port) {
+    esploader = new ESPLoader(params.port, console);
+  } else {
+    try {
+      esploader = await connect(console);
+    } catch (err: any) {
+      if ((err as DOMException).name !== "NotFoundError") {
+        alert(`Unable to connect: ${err.message}`);
+      }
+      return false;
+    }
+  }
+
   const dialog = document.createElement("esphome-install-web-dialog");
-  dialog.configuration = configuration;
+  dialog.params = params;
   dialog.esploader = esploader;
   document.body.append(dialog);
+  return true;
 };


### PR DESCRIPTION
Refactor the install-web dialog to make it also usable with passing in files to install directly.