### PR TITLE
Point users to ESPHome Web

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -39,8 +39,22 @@ export const deleteConfiguration = (configuration: string) =>
     method: "post",
   });
 
-export const compileConfiguration = (configuration: string) =>
-  streamLogs("compile", { configuration });
+export const compileConfiguration = (
+  configuration: string,
+  abortController?: AbortController
+) => new Promise((_, reject) => setTimeout(reject, 2000));
+// ) => streamLogs("compile", { configuration }, undefined, abortController);
 
 export const getConfigurationManifest = (configuration: string) =>
   fetchApiJson<Manifest>(`./manifest.json?configuration=${configuration}`);
+
+export const getDownloadUrl = (
+  configuration: string,
+  factoryFirmware: boolean
+) => {
+  let url = `./download.bin?configuration=${encodeURIComponent(configuration)}`;
+  if (factoryFirmware) {
+    url += "&type=firmware-factory.bin";
+  }
+  return url;
+};

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -42,8 +42,7 @@ export const deleteConfiguration = (configuration: string) =>
 export const compileConfiguration = (
   configuration: string,
   abortController?: AbortController
-) => new Promise((_, reject) => setTimeout(reject, 2000));
-// ) => streamLogs("compile", { configuration }, undefined, abortController);
+) => streamLogs("compile", { configuration }, undefined, abortController);
 
 export const getConfigurationManifest = (configuration: string) =>
   fetchApiJson<Manifest>(`./manifest.json?configuration=${configuration}`);

--- a/src/compile/compile-dialog.ts
+++ b/src/compile/compile-dialog.ts
@@ -4,6 +4,7 @@ import "@material/mwc-button";
 import "../components/remote-process";
 import "../components/process-dialog";
 import { openCompileDialog } from ".";
+import { getDownloadUrl } from "../api/configuration";
 
 @customElement("esphome-compile-dialog")
 class ESPHomeCompileDialog extends LitElement {
@@ -26,7 +27,13 @@ class ESPHomeCompileDialog extends LitElement {
           ? ""
           : this._result === 0
           ? html`
-              <a slot="secondaryAction" href="${this.downloadUrl}">
+              <a
+                slot="secondaryAction"
+                href="${getDownloadUrl(
+                  this.configuration,
+                  this.downloadFactoryFirmware
+                )}"
+              >
                 <mwc-button label="Download"></mwc-button>
               </a>
             `
@@ -42,16 +49,6 @@ class ESPHomeCompileDialog extends LitElement {
     `;
   }
 
-  private get downloadUrl() {
-    let url = `./download.bin?configuration=${encodeURIComponent(
-      this.configuration
-    )}`;
-    if (this.downloadFactoryFirmware) {
-      url += "&type=firmware-factory.bin";
-    }
-    return url;
-  }
-
   private _handleProcessDone(ev: { detail: number }) {
     this._result = ev.detail;
 
@@ -61,7 +58,10 @@ class ESPHomeCompileDialog extends LitElement {
 
     const link = document.createElement("a");
     link.download = this.configuration + ".bin";
-    link.href = this.downloadUrl;
+    link.href = getDownloadUrl(
+      this.configuration,
+      this.downloadFactoryFirmware
+    );
     document.body.appendChild(link);
     link.click();
     link.remove();

--- a/src/compile/compile-dialog.ts
+++ b/src/compile/compile-dialog.ts
@@ -9,6 +9,8 @@ import { openCompileDialog } from ".";
 class ESPHomeCompileDialog extends LitElement {
   @property() public configuration!: string;
 
+  @property() public downloadFactoryFirmware = true;
+
   @state() private _result?: number;
 
   protected render() {
@@ -24,12 +26,7 @@ class ESPHomeCompileDialog extends LitElement {
           ? ""
           : this._result === 0
           ? html`
-              <a
-                slot="secondaryAction"
-                href="${`./download.bin?configuration=${encodeURIComponent(
-                  this.configuration
-                )}`}"
-              >
+              <a slot="secondaryAction" href="${this.downloadUrl}">
                 <mwc-button label="Download"></mwc-button>
               </a>
             `
@@ -45,6 +42,16 @@ class ESPHomeCompileDialog extends LitElement {
     `;
   }
 
+  private get downloadUrl() {
+    let url = `./download.bin?configuration=${encodeURIComponent(
+      this.configuration
+    )}`;
+    if (this.downloadFactoryFirmware) {
+      url += "&type=firmware-factory.bin";
+    }
+    return url;
+  }
+
   private _handleProcessDone(ev: { detail: number }) {
     this._result = ev.detail;
 
@@ -54,16 +61,14 @@ class ESPHomeCompileDialog extends LitElement {
 
     const link = document.createElement("a");
     link.download = this.configuration + ".bin";
-    link.href = `./download.bin?configuration=${encodeURIComponent(
-      this.configuration
-    )}`;
+    link.href = this.downloadUrl;
     document.body.appendChild(link);
     link.click();
     link.remove();
   }
 
   private _handleRetry() {
-    openCompileDialog(this.configuration);
+    openCompileDialog(this.configuration, this.downloadFactoryFirmware);
   }
 
   private _handleClose() {

--- a/src/compile/index.ts
+++ b/src/compile/index.ts
@@ -1,8 +1,12 @@
 const preload = () => import("./compile-dialog");
 
-export const openCompileDialog = (configuration: string) => {
+export const openCompileDialog = (
+  configuration: string,
+  downloadFactoryFirmware: boolean
+) => {
   preload();
   const dialog = document.createElement("esphome-compile-dialog");
   dialog.configuration = configuration;
+  dialog.downloadFactoryFirmware = downloadFactoryFirmware;
   document.body.append(dialog);
 };

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -22,7 +22,7 @@ export const getConfigurationFiles = async (
     const resp = await fetch(url);
     if (!resp.ok) {
       throw new Error(
-        `Downlading firmware ${part.path} failed: ${resp.status}`
+        `Downloading firmware ${part.path} failed: ${resp.status}`
       );
     }
     return resp.arrayBuffer();

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -316,16 +316,6 @@ class ESPHomeInstallChooseDialog extends LitElement {
       line-height: 80px;
       color: black;
     }
-    button.link {
-      background: none;
-      color: var(--mdc-theme-primary);
-      border: none;
-      padding: 0;
-      font: inherit;
-      text-align: left;
-      text-decoration: underline;
-      cursor: pointer;
-    }
     .show-ports {
       margin-top: 16px;
     }

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -69,7 +69,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
           twoline
           hasMeta
           dialogAction="close"
-          @click=${this._showCompileDialog}
+          @click=${this._handleManualDownload}
         >
           <span>Manual download</span>
           <span slot="secondary">
@@ -151,7 +151,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
           href=${ESPHOME_WEB_URL}
           target="_blank"
           rel="noopener"
-          @click=${this._showCompileDialog}
+          @click=${this._handleWebDownload}
         >
           <mwc-button dialogAction="close" label="Download"></mwc-button>
         </a>
@@ -252,8 +252,12 @@ class ESPHomeInstallChooseDialog extends LitElement {
     this._state = "pick_server_port";
   }
 
-  private _showCompileDialog() {
-    openCompileDialog(this.configuration);
+  private _handleManualDownload() {
+    openCompileDialog(this.configuration, false);
+  }
+
+  private _handleWebDownload() {
+    openCompileDialog(this.configuration, true);
   }
 
   private _handleLegacyOption(ev: Event) {

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -160,7 +160,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
   }
 
   private _showCompileDialog() {
-    openCompileDialog(this.params.configuration!);
+    openCompileDialog(this.params.configuration!, false);
     this._close();
   }
 

--- a/src/logs-target/logs-target-dialog.ts
+++ b/src/logs-target/logs-target-dialog.ts
@@ -7,13 +7,10 @@ import "../components/remote-process";
 import "../components/process-dialog";
 import { openLogsDialog } from "../logs";
 import { getSerialPorts, ServerSerialPort } from "../api/serial-ports";
-import {
-  allowsWebSerial,
-  metaChevronRight,
-  metaHelp,
-  supportsWebSerial,
-} from "../const";
+import { allowsWebSerial, metaChevronRight, supportsWebSerial } from "../const";
 import { openLogsWebSerialDialog } from "../logs-webserial";
+
+const ESPHOME_WEB_URL = "https://web.esphome.io/?dashboard_logs";
 
 @customElement("esphome-logs-target-dialog")
 class ESPHomeLogsTargetDialog extends LitElement {
@@ -21,58 +18,82 @@ class ESPHomeLogsTargetDialog extends LitElement {
 
   @state() private _ports?: ServerSerialPort[];
 
-  @state() private _show: "options" | "server_ports" = "options";
+  @state() private _show: "options" | "web_instructions" | "server_ports" =
+    "options";
 
   protected render() {
-    return html`
-      <mwc-dialog
-        open
-        heading=${this._show === "options"
-          ? "How to get the logs for your ESP device?"
-          : "Pick server port"}
-        scrimClickAction
-        @closed=${this._handleClose}
-      >
-        ${this._show === "options"
-          ? html`
-              <mwc-list-item
-                twoline
-                hasMeta
-                dialogAction="close"
-                .port=${"OTA"}
-                @click=${this._pickPort}
-              >
-                <span>Wirelessly</span>
-                <span slot="secondary">Requires the device to be online</span>
-                ${metaChevronRight}
-              </mwc-list-item>
+    let heading;
+    let content;
 
-              <mwc-list-item
-                twoline
-                hasMeta
-                .port=${"WEBSERIAL"}
-                @click=${this._pickWebSerial}
-              >
-                <span>Plug into this computer</span>
-                <span slot="secondary">
-                  ${supportsWebSerial
-                    ? "For devices connected via USB to this computer"
-                    : allowsWebSerial
-                    ? "Your browser is not supported"
-                    : "Dashboard needs to opened via HTTPS"}
-                </span>
-                ${supportsWebSerial ? metaChevronRight : metaHelp}
-              </mwc-list-item>
+    if (this._show === "options") {
+      heading = "How to get the logs for your ESP device?";
+      content = html`
+        <mwc-list-item
+          twoline
+          hasMeta
+          dialogAction="close"
+          .port=${"OTA"}
+          @click=${this._pickPort}
+        >
+          <span>Wirelessly</span>
+          <span slot="secondary">Requires the device to be online</span>
+          ${metaChevronRight}
+        </mwc-list-item>
 
-              <mwc-list-item twoline hasMeta @click=${this._showServerPorts}>
-                <span>Plug into the computer running ESPHome Dashboard</span>
-                <span slot="secondary">
-                  For devices connected via USB to the server
-                </span>
-                ${metaChevronRight}
-              </mwc-list-item>
-            `
-          : this._ports === undefined
+        <mwc-list-item
+          twoline
+          hasMeta
+          .port=${"WEBSERIAL"}
+          @click=${this._pickWebSerial}
+        >
+          <span>Plug into this computer</span>
+          <span slot="secondary">
+            For devices connected via USB to this computer
+          </span>
+          ${metaChevronRight}
+        </mwc-list-item>
+
+        <mwc-list-item twoline hasMeta @click=${this._showServerPorts}>
+          <span>Plug into the computer running ESPHome Dashboard</span>
+          <span slot="secondary">
+            For devices connected via USB to the server
+          </span>
+          ${metaChevronRight}
+        </mwc-list-item>
+      `;
+    } else if (this._show === "web_instructions") {
+      heading = "View logs in the browser";
+      content = html`
+        <p>
+          ESPHome can view the logs of your device via the browser if certain
+          requirements are met:
+        </p>
+        <ul>
+          <li>ESPHome is visited over HTTPS</li>
+          <li>Your browser supports WebSerial</li>
+        </ul>
+        <p>
+          Not all requirements are currently met. The easiest solution is to
+          view the logs with ESPHome Web. ESPHome Web works 100% in your browser
+          and no data will be shared with the ESPHome project.
+        </p>
+
+        <a
+          slot="primaryAction"
+          href=${ESPHOME_WEB_URL}
+          target="_blank"
+          rel="noopener"
+        >
+          <mwc-button
+            dialogAction="close"
+            label="OPEN ESPHOME WEB"
+          ></mwc-button>
+        </a>
+      `;
+    } else {
+      heading = "Pick server port";
+      content =
+        this._ports === undefined
           ? html`
               <mwc-list-item>
                 <span>Loading ports…</span>
@@ -98,7 +119,17 @@ class ESPHomeLogsTargetDialog extends LitElement {
                   ${metaChevronRight}
                 </mwc-list-item>
               `
-            )}
+            );
+    }
+
+    return html`
+      <mwc-dialog
+        open
+        heading=${heading}
+        scrimClickAction
+        @closed=${this._handleClose}
+      >
+        ${content}
 
         <mwc-button
           no-attention
@@ -133,10 +164,7 @@ class ESPHomeLogsTargetDialog extends LitElement {
 
   private async _pickWebSerial(ev: Event) {
     if (!supportsWebSerial || !allowsWebSerial) {
-      window.open(
-        "https://esphome.io/guides/getting_started_hassio.html#webserial",
-        "_blank"
-      );
+      this._show = "web_instructions";
       return;
     }
 
@@ -157,6 +185,11 @@ class ESPHomeLogsTargetDialog extends LitElement {
   static styles = css`
     mwc-list-item {
       margin: 0 -20px;
+    }
+
+    mwc-button[no-attention] {
+      --mdc-theme-primary: #444;
+      --mdc-theme-on-primary: white;
     }
   `;
 }


### PR DESCRIPTION
Update the install and logs dialogs to offer users instructions to open ESPHome Web

When clicking "Install via device connected to this computer":


https://user-images.githubusercontent.com/1444314/148885080-a0219d57-8840-4998-a46e-e3217c6885e0.mp4


![CleanShot 2022-01-10 at 21 11 55](https://user-images.githubusercontent.com/1444314/148885093-b1332ce5-f350-4ac4-98dd-46d1d490ed82.png)


When clicking "View logs via device connected to this computer":

![image](https://user-images.githubusercontent.com/1444314/148858363-003eb0ef-9459-440e-83d9-6a045bb9a9c5.png)
