### PR TITLE
[Web] Highlight features for connected devices

### DIFF
--- a/web.esphome.io/src/dashboard/ew-dashboard.ts
+++ b/web.esphome.io/src/dashboard/ew-dashboard.ts
@@ -1,9 +1,19 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, html, css, PropertyValues } from "lit";
 import { customElement } from "lit/decorators.js";
 import "@material/mwc-button";
 import "./unsupported-card";
 import "./connect-card";
 import { supportsWebSerial } from "../../../src/const";
+
+const ARROW = html`
+  <div class="arrow">
+    <svg width="48" height="48" viewBox="0 0 24 24">
+      <path
+        d="M20 18V20H13.5C9.91 20 7 17.09 7 13.5V7.83L3.91 10.92L2.5 9.5L8 4L13.5 9.5L12.09 10.91L9 7.83V13.5C9 16 11 18 13.5 18H20Z"
+      />
+    </svg>
+  </div>
+`;
 
 @customElement("ew-dashboard")
 class EWDashboard extends LitElement {
@@ -13,19 +23,18 @@ class EWDashboard extends LitElement {
         ${supportsWebSerial
           ? html`<ew-connect-card></ew-connect-card>`
           : html`<ew-unsupported-card></ew-unsupported-card>`}
+
         <div class="intro">
-          <div class="arrow">
-            <svg width="48" height="48" viewBox="0 0 24 24">
-              <path
-                d="M20 18V20H13.5C9.91 20 7 17.09 7 13.5V7.83L3.91 10.92L2.5 9.5L8 4L13.5 9.5L12.09 10.91L9 7.83V13.5C9 16 11 18 13.5 18H20Z"
-              />
-            </svg>
-          </div>
+          ${ARROW}
           <div class="text">
             <p><b>Welcome to ESPHome Web!</b></p>
             <p>
               ESPHome Web allows you to install new versions and check the logs
               of your ESP device directly from your browser.
+            </p>
+            <p>
+              ESPHome Web runs 100% in your browser. No data will leave your
+              computer.
             </p>
             <p>
               This page is a lite variant of ESPHome. If you want to create and
@@ -39,8 +48,38 @@ class EWDashboard extends LitElement {
             </p>
           </div>
         </div>
+
+        <div class="promote promote-install">
+          ${ARROW}
+          <div class="text">
+            <p><b>Install downloaded project</b></p>
+            <p>
+              If you have a downloaded version of your project, you can install
+              it on your ESP device here.
+            </p>
+          </div>
+        </div>
+
+        <div class="promote promote-logs">
+          ${ARROW}
+          <div class="text">
+            <p><b>Check logs</b></p>
+            <p>
+              Click here to check the logs of your device. If you don't see logs
+              output, press the reset device button.
+            </p>
+          </div>
+        </div>
       </div>
     `;
+  }
+
+  protected firstUpdated(changedProps: PropertyValues): void {
+    super.firstUpdated(changedProps);
+    const highlight = location.search.substring(1);
+    if (highlight === "dashboard_install" || highlight === "dashboard_logs") {
+      this.toggleAttribute(highlight);
+    }
   }
 
   static styles = css`
@@ -61,15 +100,32 @@ class EWDashboard extends LitElement {
       width: 100%;
       max-width: 450px;
     }
-    .intro {
+    .intro,
+    .promote {
       position: relative;
-      transition: opacity 0.3s;
       display: flex;
-      padding: 32px 0 0 32px;
+      padding-top: 32px;
+    }
+    .intro {
+      padding-left: 32px;
     }
     ew-connect-card[connected] + .intro {
-      opacity: 0;
-      pointer-events: none;
+      display: none;
+    }
+    .promote-install {
+      padding-left: 83px;
+    }
+    .promote-logs {
+      padding-left: 20px;
+    }
+    ew-connect-card ~ .promote {
+      display: none;
+    }
+    :host([dashboard_logs]) ew-connect-card[connected] ~ .promote-logs {
+      display: flex;
+    }
+    :host([dashboard_install]) ew-connect-card[connected] ~ .promote-install {
+      display: flex;
     }
     .text {
       margin-left: 16px;
@@ -78,7 +134,7 @@ class EWDashboard extends LitElement {
     }
     .arrow svg {
       position: relative;
-      top: -11px;
+      top: -13px;
     }
     @media only screen and (max-width: 550px) {
       :host {


### PR DESCRIPTION
ESPHome will add the reason a user is referred to ESPHome Web in the URL ([install](https://github.com/esphome/dashboard/blob/main/src/install-choose/install-choose-dialog.ts#L16), [logs](https://github.com/esphome/dashboard/blob/main/src/logs-target/logs-target-dialog.ts#L13)). 

This PR will add a highlight to the feature the user is coming for once the device is connected.

# Highlight install

![image](https://user-images.githubusercontent.com/1444314/148887795-99f6edbb-6f73-4089-bd35-67d5c8438947.png)

# Highlight logs

![image](https://user-images.githubusercontent.com/1444314/148887830-1c2e54e7-646d-4b4d-8072-7c74875e9619.png)
