### PR TITLE
Suggest ESPHome Web in the wizard

### DIFF
--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -116,9 +116,11 @@ class ESPHomeInstallChooseDialog extends LitElement {
 
               <mwc-button
                 no-attention
-                slot="secondaryAction"
-                dialogAction="close"
-                label="Cancel"
+                slot="primaryAction"
+                label="Back"
+                @click=${() => {
+                  this._state = "pick_option";
+                }}
               ></mwc-button>
             `;
     } else if (this._state === "web_instructions") {
@@ -160,8 +162,10 @@ class ESPHomeInstallChooseDialog extends LitElement {
         <mwc-button
           no-attention
           slot="secondaryAction"
-          dialogAction="close"
-          label="Cancel"
+          label="Back"
+          @click=${() => {
+            this._state = "pick_option";
+          }}
         ></mwc-button>
       `;
     }

--- a/src/logs-target/logs-target-dialog.ts
+++ b/src/logs-target/logs-target-dialog.ts
@@ -60,6 +60,12 @@ class ESPHomeLogsTargetDialog extends LitElement {
           </span>
           ${metaChevronRight}
         </mwc-list-item>
+        <mwc-button
+          no-attention
+          slot="primaryAction"
+          dialogAction="close"
+          label="Cancel"
+        ></mwc-button>
       `;
     } else if (this._show === "web_instructions") {
       heading = "View logs in the browser";
@@ -89,11 +95,18 @@ class ESPHomeLogsTargetDialog extends LitElement {
             label="OPEN ESPHOME WEB"
           ></mwc-button>
         </a>
+        <mwc-button
+          no-attention
+          slot="secondaryAction"
+          label="Back"
+          @click=${() => {
+            this._show = "options";
+          }}
+        ></mwc-button>
       `;
     } else {
       heading = "Pick server port";
-      content =
-        this._ports === undefined
+      content = html`${this._ports === undefined
           ? html`
               <mwc-list-item>
                 <span>Loading ports…</span>
@@ -119,7 +132,16 @@ class ESPHomeLogsTargetDialog extends LitElement {
                   ${metaChevronRight}
                 </mwc-list-item>
               `
-            );
+            )}
+
+        <mwc-button
+          no-attention
+          slot="primaryAction"
+          label="Back"
+          @click=${() => {
+            this._show = "options";
+          }}
+        ></mwc-button>`;
     }
 
     return html`
@@ -130,13 +152,6 @@ class ESPHomeLogsTargetDialog extends LitElement {
         @closed=${this._handleClose}
       >
         ${content}
-
-        <mwc-button
-          no-attention
-          slot="secondaryAction"
-          dialogAction="close"
-          label="Cancel"
-        ></mwc-button>
       </mwc-dialog>
     `;
   }

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -229,23 +229,6 @@ export class ESPHomeWizardDialog extends LitElement {
     const heading = "New device";
     let hideActions = false;
     const content = html`
-      ${supportsWebSerial
-        ? ""
-        : html`
-            <div class="notice">
-              Limited functionality because
-              ${allowsWebSerial
-                ? html`
-                    your browser does not support WebSerial.
-                    <a
-                      href="https://esphome.io/guides/getting_started_hassio.html#webserial"
-                      target="_blank"
-                      >Learn more</a
-                    >
-                  `
-                : "you're not browsing the dashboard over a secure connection (HTTPS)."}
-            </div>
-          `}
       ${this._error ? html`<div class="error">${this._error}</div>` : ""}
 
       <mwc-textfield
@@ -745,11 +728,6 @@ export class ESPHomeWizardDialog extends LitElement {
       font-size: 50px;
       line-height: 80px;
       color: black;
-    }
-    .notice {
-      padding: 8px 24px;
-      background-color: #fff59d;
-      margin: 0 -24px;
     }
     .error {
       color: #db4437;

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -226,7 +226,7 @@ export class ESPHomeWizardDialog extends LitElement {
     if (this._hasWifiSecrets === undefined) {
       return [undefined, this._renderProgress("Initializing"), true];
     }
-    const heading = "New device";
+    const heading = supportsWebSerial ? "New device" : "Create configuration";
     let hideActions = false;
     const content = html`
       ${this._error ? html`<div class="error">${this._error}</div>` : ""}

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -35,6 +35,7 @@ import { openInstallChooseDialog } from "../install-choose";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
+const ESPHOME_WEB_URL = "https://web.esphome.io/?dashboard_wizard";
 
 /*
 Flow:
@@ -66,6 +67,7 @@ export class ESPHomeWizardDialog extends LitElement {
   @state() private _writeProgress?: number;
 
   @state() private _state:
+    | "ask_esphome_web"
     | "basic_config"
     | "connect_webserial"
     | "pick_board"
@@ -73,7 +75,7 @@ export class ESPHomeWizardDialog extends LitElement {
     | "prepare_flash"
     | "flashing"
     | "wait_come_online"
-    | "done" = "basic_config";
+    | "done" = supportsWebSerial ? "basic_config" : "ask_esphome_web";
 
   @state() private _error?: string;
 
@@ -88,7 +90,9 @@ export class ESPHomeWizardDialog extends LitElement {
     let content;
     let hideActions = false;
 
-    if (this._state === "basic_config") {
+    if (this._state === "ask_esphome_web") {
+      [heading, content, hideActions] = this._renderAskESPHomeWeb();
+    } else if (this._state === "basic_config") {
       [heading, content, hideActions] = this._renderBasicConfig();
     } else if (this._state === "pick_board") {
       heading = "Select your ESP device";
@@ -170,6 +174,52 @@ export class ESPHomeWizardDialog extends LitElement {
         ></mwc-button>
       `}
     `;
+  }
+
+  private _renderAskESPHomeWeb(): [
+    string | undefined,
+    TemplateResult,
+    boolean
+  ] {
+    const heading = "New device";
+    let hideActions = false;
+    const content = html`
+      <div>
+        ${allowsWebSerial
+          ? "Your browser does not support WebSerial."
+          : "You are not browsing the dashboard over a secure connection (HTTPS)."}
+        This prevents ESPHome wizard from offering the easiest experience to add
+        a new device.
+      </div>
+      <div>
+        We recommend to visit ESPHome Web to create an adoptable device using
+        your browser.
+      </div>
+      <div>
+        You can also choose to create a configuration and try one of the other
+        installation methods.
+      </div>
+
+      <a
+        slot="primaryAction"
+        href=${ESPHOME_WEB_URL}
+        target="_blank"
+        rel="noopener"
+      >
+        <mwc-button dialogAction="close" label="Open ESPHome Web"></mwc-button>
+      </a>
+
+      <mwc-button
+        no-attention
+        slot="secondaryAction"
+        label="Create Configuration"
+        @click=${() => {
+          this._state = "basic_config";
+        }}
+      ></mwc-button>
+    `;
+
+    return [heading, content, hideActions];
   }
 
   private _renderBasicConfig(): [string | undefined, TemplateResult, boolean] {

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -165,14 +165,15 @@ export class ESPHomeWizardDialog extends LitElement {
         <div class="icon">${icon}</div>
         ${label}
       </div>
-      ${showClose &&
-      html`
-        <mwc-button
-          slot="primaryAction"
-          dialogAction="ok"
-          label="Close"
-        ></mwc-button>
-      `}
+      ${showClose
+        ? html`
+            <mwc-button
+              slot="primaryAction"
+              dialogAction="ok"
+              label="Close"
+            ></mwc-button>
+          `
+        : ""}
     `;
   }
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -196,8 +196,9 @@ export class ESPHomeWizardDialog extends LitElement {
         your browser.
       </div>
       <div>
-        You can also choose to create a configuration and try one of the other
-        installation methods.
+        Alternatively, you can use the wizard to create a configuration and
+        install it by connecting your device to the computer that runs the
+        ESPHome dashboard.
       </div>
 
       <a

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -186,35 +186,42 @@ export class ESPHomeWizardDialog extends LitElement {
     let hideActions = false;
     const content = html`
       <div>
+        A device needs to be connected to a computer using a USB cable to be
+        added to ESPHome. Once added, ESPHome will interact with the device
+        wirelessly.
+      </div>
+      <div>
         ${allowsWebSerial
           ? "Your browser does not support WebSerial."
           : "You are not browsing the dashboard over a secure connection (HTTPS)."}
-        This prevents ESPHome wizard from offering the easiest experience to add
-        a new device.
+        This prevents ESPHome from being able to install this on devices
+        connected to this computer.
       </div>
       <div>
-        We recommend to visit ESPHome Web to create an adoptable device using
-        your browser.
+        You will still be able to install ESPHome by connecting the device to
+        the computer that runs the ESPHome dashboard.
       </div>
       <div>
-        Alternatively, you can use the wizard to create a configuration and
-        install it by connecting your device to the computer that runs the
-        ESPHome dashboard.
+        Alternatively, you can use ESPHome Web to prepare a device for being
+        used with ESPHome using this computer.
       </div>
 
       <a
-        slot="primaryAction"
+        slot="secondaryAction"
         href=${ESPHOME_WEB_URL}
         target="_blank"
         rel="noopener"
       >
-        <mwc-button dialogAction="close" label="Open ESPHome Web"></mwc-button>
+        <mwc-button
+          no-attention
+          dialogAction="close"
+          label="Open ESPHome Web"
+        ></mwc-button>
       </a>
 
       <mwc-button
-        no-attention
-        slot="secondaryAction"
-        label="Create Configuration"
+        slot="primaryAction"
+        label="Continue"
         @click=${() => {
           this._state = "basic_config";
         }}
@@ -749,7 +756,7 @@ export class ESPHomeWizardDialog extends LitElement {
       cursor: pointer;
     }
 
-    mwc-button[slot="secondaryAction"] {
+    mwc-button[no-attention] {
       --mdc-theme-primary: #444;
       --mdc-theme-on-primary: white;
     }


### PR DESCRIPTION
This PR suggests to use ESPHome Web when a user clicks "Add device". This replaces the step to ask for the name. That page will be shown when the user clicks "Create configuration". 

This design is an initial suggestion. Alternative is to expand the notice.

![image](https://user-images.githubusercontent.com/1444314/149204231-7fb0e704-bbe6-41e8-aa7c-5a6bdc719eb9.png)


~~Marked as draft until we can adopt + rename in 1 go. Until then adoption to onboard new devices is not a good user experience.~~