### PR TITLE
Allow configuring Wi-Fi

### DIFF
--- a/web.esphome.io/src/dashboard/device-card.ts
+++ b/web.esphome.io/src/dashboard/device-card.ts
@@ -49,6 +49,7 @@ class EWDeviceCard extends LitElement {
             @action=${this._handleOverflowAction}
           >
             <mwc-icon-button slot="trigger" icon="more_vert"></mwc-icon-button>
+            <mwc-list-item>Configure Wi-Fi</mwc-list-item>
             <mwc-list-item>Disconnect</mwc-list-item>
           </esphome-button-menu>
       </esphome-card>
@@ -77,6 +78,14 @@ class EWDeviceCard extends LitElement {
   private _handleOverflowAction(ev: CustomEvent<ActionDetail>) {
     switch (ev.detail.index) {
       case 0:
+        import("improv-wifi-serial-sdk/dist/serial-provision-dialog");
+        const improv = document.createElement(
+          "improv-wifi-serial-provision-dialog"
+        );
+        improv.port = this.port;
+        document.body.appendChild(improv);
+        break;
+      case 1:
         this.port.close();
         fireEvent(this, "close");
         break;


### PR DESCRIPTION
Add menu option to configure wifi. We already automatically opened this after making a device adoptable.

![image](https://user-images.githubusercontent.com/1444314/149034041-12cac7ca-82ba-4d00-8a56-3e6b771bfaaa.png)
