### PR TITLE
Fix dialog height on iOS

### DIFF
--- a/raw_package/base.template.html
+++ b/raw_package/base.template.html
@@ -34,12 +34,8 @@
     <main>{% block main %}{% end %}</main>
 
     <div class="esphome-header">
-      <div>
-        <img
-          src="https://esphome.io/_static/logo-text.svg"
-          alt="ESPHome Logo"
-        />
-      </div>
+      <img src="https://esphome.io/_static/logo-text.svg" alt="ESPHome Logo" />
+      <div class="flex"></div>
       {% block header %}{% end %}
     </div>
 

--- a/raw_package/index.template.html
+++ b/raw_package/index.template.html
@@ -32,7 +32,7 @@
 
 <div id="js-editor-modal" class="modal modal-fixed-footer no-autoinit">
   <div class="modal-content">
-    <h4>Editing: <code id="js-node-filename" class="inlinecode"></code></h4>
+    <h4 id="js-node-filename"></h4>
 
     <div id="js-loading-indicator">
       <div class="preloader-wrapper big active">

--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -44,7 +44,7 @@ main {
   padding: 0 24px;
 }
 
-.esphome-header > div {
+.flex {
   flex: 1;
 }
 
@@ -137,7 +137,8 @@ ul.browser-default li {
   .modal {
     top: 0 !important;
     width: 100vw;
-    height: 100vh !important;
+    height: 90vh !important;
+    height: calc(90vh - env(safe-area-inset-bottom)) !important;
     max-height: initial;
   }
   .modal h4 {

--- a/src/components/process-dialog.ts
+++ b/src/components/process-dialog.ts
@@ -4,6 +4,7 @@ import "@material/mwc-dialog";
 import "@material/mwc-button";
 import "../components/remote-process";
 import { fireEvent } from "../util/fire-event";
+import { esphomeDialogStyles } from "../styles";
 
 @customElement("esphome-process-dialog")
 export class ESPHomeProcessDialog extends LitElement {
@@ -51,16 +52,33 @@ export class ESPHomeProcessDialog extends LitElement {
     fireEvent(this, "closed");
   }
 
-  static styles = css`
-    mwc-dialog {
-      --mdc-dialog-min-width: 95vw;
-      --mdc-dialog-max-width: 95vw;
-    }
+  static styles = [
+    esphomeDialogStyles,
+    css`
+      :host {
+        --height-header-footer-padding: 152px;
+      }
+      mwc-dialog {
+        --mdc-dialog-min-width: 95vw;
+        --mdc-dialog-max-width: 95vw;
+      }
 
-    esphome-remote-process {
-      height: calc(90vh - 128px);
-    }
-  `;
+      esphome-remote-process {
+        height: calc(90vh - var(--height-header-footer-padding));
+      }
+
+      @media only screen and (max-width: 450px) {
+        esphome-remote-process {
+          height: calc(
+            90vh - var(--height-header-footer-padding) -
+              env(safe-area-inset-bottom)
+          );
+          margin-left: -24px;
+          margin-right: -24px;
+        }
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -80,4 +80,15 @@ export const esphomeDialogStyles = css`
     --mdc-theme-primary: #444;
     --mdc-theme-on-primary: white;
   }
+
+  @media only screen and (max-width: 450px) {
+    mwc-dialog {
+      --mdc-dialog-min-width: 100vw !important;
+      --mdc-dialog-max-width: 100vw !important;
+      --mdc-dialog-max-height: 100vh !important;
+      --mdc-dialog-max-height: calc(
+        90vh - env(safe-area-inset-bottom)
+      ) !important;
+    }
+  }
 `;


### PR DESCRIPTION
Safari is really messy with disappearing UI that captures touches near the bottom. This PR tweaks dialog heights. Tested this on iPhone + iPad to verify it is ok. Also gave the logs a bit more width on mobile.

Fixes #190

Note, this updates esphome-2.css. This file will be cached on older installations. This shouldn't be a big issue, it will just have the UI look a little weird until the cache is gone.