### PR TITLE
Allow downloading logs

### DIFF
--- a/src/components/process-dialog.ts
+++ b/src/components/process-dialog.ts
@@ -5,6 +5,8 @@ import "@material/mwc-button";
 import "../components/remote-process";
 import { fireEvent } from "../util/fire-event";
 import { esphomeDialogStyles } from "../styles";
+import { textDownload } from "../util/file-download";
+import { basename } from "../util/basename";
 
 @customElement("esphome-process-dialog")
 export class ESPHomeProcessDialog extends LitElement {
@@ -31,6 +33,12 @@ export class ESPHomeProcessDialog extends LitElement {
           @process-done=${this._handleProcessDone}
         ></esphome-remote-process>
 
+        <mwc-button
+          slot="secondaryAction"
+          label="Download Logs"
+          @click=${this._downloadLogs}
+        ></mwc-button>
+
         <slot name="secondaryAction" slot="secondaryAction"></slot>
 
         <mwc-button
@@ -50,6 +58,20 @@ export class ESPHomeProcessDialog extends LitElement {
 
   private _handleClose() {
     fireEvent(this, "closed");
+  }
+
+  private _downloadLogs() {
+    let filename = "logs";
+    if (this.spawnParams?.configuration) {
+      // Append filename without extension
+      filename += `_${basename(this.spawnParams.configuration)}`;
+    }
+    filename += `_${this.type}.txt`;
+
+    textDownload(
+      this.shadowRoot!.querySelector("esphome-remote-process")!.logs(),
+      filename
+    );
   }
 
   static styles = [

--- a/src/components/remote-process.ts
+++ b/src/components/remote-process.ts
@@ -11,6 +11,10 @@ class ESPHomeRemoteProcess extends HTMLElement {
   private _abortController?: AbortController;
   private _setup = false;
 
+  public logs(): string {
+    return this.shadowRoot!.querySelector("div")!.innerText;
+  }
+
   public connectedCallback() {
     if (this._setup) {
       return;

--- a/src/components/remote-process.ts
+++ b/src/components/remote-process.ts
@@ -8,18 +8,17 @@ class ESPHomeRemoteProcess extends HTMLElement {
   public type!: "validate" | "logs" | "upload" | "clean-mqtt" | "clean";
   public spawnParams!: Record<string, any>;
 
+  private _coloredConsole?: ColoredConsole;
   private _abortController?: AbortController;
-  private _setup = false;
 
   public logs(): string {
-    return this.shadowRoot!.querySelector("div")!.innerText;
+    return this._coloredConsole?.logs() || "";
   }
 
   public connectedCallback() {
-    if (this._setup) {
+    if (this._coloredConsole) {
       return;
     }
-    this._setup = true;
     const shadowRoot = this.attachShadow({ mode: "open" });
 
     shadowRoot.innerHTML = `
@@ -33,6 +32,7 @@ class ESPHomeRemoteProcess extends HTMLElement {
     `;
 
     const coloredConsole = new ColoredConsole(shadowRoot.querySelector("div")!);
+    this._coloredConsole = coloredConsole;
     this._abortController = new AbortController();
 
     streamLogs(
@@ -55,6 +55,7 @@ class ESPHomeRemoteProcess extends HTMLElement {
   public disconnectedCallback() {
     if (this._abortController) {
       this._abortController.abort();
+      this._abortController = undefined;
     }
   }
 }

--- a/src/logs-webserial/ewt-console.ts
+++ b/src/logs-webserial/ewt-console.ts
@@ -12,7 +12,7 @@ export class EwtConsole extends HTMLElement {
   private _cancelConnection?: () => Promise<void>;
 
   public logs(): string {
-    return this.shadowRoot!.querySelector("div")!.innerText;
+    return this._console?.logs() || "";
   }
 
   public connectedCallback() {

--- a/src/logs-webserial/ewt-console.ts
+++ b/src/logs-webserial/ewt-console.ts
@@ -11,6 +11,10 @@ export class EwtConsole extends HTMLElement {
   private _console?: ColoredConsole;
   private _cancelConnection?: () => Promise<void>;
 
+  public logs(): string {
+    return this.shadowRoot!.querySelector("div")!.innerText;
+  }
+
   public connectedCallback() {
     if (this._console) {
       return;

--- a/src/logs-webserial/logs-webserial-dialog.ts
+++ b/src/logs-webserial/logs-webserial-dialog.ts
@@ -1,8 +1,11 @@
 import { LitElement, html, css } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import "@material/mwc-dialog";
 import "@material/mwc-button";
 import "./ewt-console";
+import { textDownload } from "../util/file-download";
+import type { EwtConsole } from "./ewt-console";
+import { basename } from "../util/basename";
 
 @customElement("esphome-logs-webserial-dialog")
 class ESPHomeLogsWebSerialDialog extends LitElement {
@@ -11,6 +14,8 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
   @property() public port!: SerialPort;
 
   @property() public closePortOnClose!: boolean;
+
+  @query("ewt-console") private _console!: EwtConsole;
 
   protected render() {
     return html`
@@ -25,6 +30,11 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
           .logger=${console}
           .allowInput=${false}
         ></ewt-console>
+        <mwc-button
+          slot="secondaryAction"
+          label="Download Logs"
+          @click=${this._downloadLogs}
+        ></mwc-button>
         ${this.configuration
           ? html`
               <mwc-button
@@ -55,7 +65,7 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
   }
 
   private async _handleClose() {
-    await this.shadowRoot!.querySelector("ewt-console")!.disconnect();
+    await this._console.disconnect();
     if (this.closePortOnClose) {
       await this.port.close();
     }
@@ -63,7 +73,16 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
   }
 
   private async _resetDevice() {
-    await this.shadowRoot!.querySelector("ewt-console")!.reset();
+    await this._console.reset();
+  }
+
+  private _downloadLogs() {
+    textDownload(
+      this._console.logs(),
+      `${
+        this.configuration ? `${basename(this.configuration)}_logs` : "logs"
+      }.txt`
+    );
   }
 
   static styles = css`

--- a/src/util/basename.ts
+++ b/src/util/basename.ts
@@ -1,0 +1,1 @@
+export const basename = (path: string) => path.replace(/\.[^/.]+$/, "");

--- a/src/util/console-color.ts
+++ b/src/util/console-color.ts
@@ -23,6 +23,10 @@ export class ColoredConsole {
 
   constructor(public targetElement: HTMLElement) {}
 
+  logs(): string {
+    return this.targetElement.innerText;
+  }
+
   addLine(line: string) {
     const re = /(?:\033|\\033)(?:\[(.*?)[@-~]|\].*?(?:\007|\033\\))/g;
     let i = 0;

--- a/src/util/file-download.ts
+++ b/src/util/file-download.ts
@@ -1,0 +1,17 @@
+export const fileDownload = (href: string, filename = ""): void => {
+  const a = document.createElement("a");
+  a.target = "_blank";
+  a.href = href;
+  a.download = filename;
+
+  document.body.appendChild(a);
+  a.dispatchEvent(new MouseEvent("click"));
+  document.body.removeChild(a);
+};
+
+export const textDownload = (text: string, filename = ""): void => {
+  const blob = new Blob([text], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  fileDownload(url, filename);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};


### PR DESCRIPTION
Add a download logs button to all dialogs that show logs (both webserial and on the server) or process output (install, validate, update all etc)

![image](https://user-images.githubusercontent.com/1444314/150612172-78711701-4351-4d10-aa08-fd8eeacf21b5.png)
