### PR TITLE
Bump improv-serial-sdk 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@polymer/paper-tooltip": "^3.0.1",
         "@types/w3c-web-serial": "^1.0.2",
         "esp-web-flasher": "^5.0.0",
-        "improv-wifi-serial-sdk": "^2.1.0",
+        "improv-wifi-serial-sdk": "^2.2.0",
         "lit": "^2.1.2",
         "tslib": "^2.3.1"
       },
@@ -479,6 +479,27 @@
         "tslib": "^2.0.1"
       }
     },
+    "node_modules/@material/mwc-select": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-select/-/mwc-select-0.25.3.tgz",
+      "integrity": "sha512-mf1WrsNAW4rDHeVH+AgTPfNHAg70dJdwuIfIBqksAty3pYxnXQ9RjpL4Z/7kLdsGiS44du65vVgmZ63T0ifugQ==",
+      "dependencies": {
+        "@material/dom": "=14.0.0-canary.261f2db59.0",
+        "@material/floating-label": "=14.0.0-canary.261f2db59.0",
+        "@material/line-ripple": "=14.0.0-canary.261f2db59.0",
+        "@material/list": "=14.0.0-canary.261f2db59.0",
+        "@material/mwc-base": "^0.25.3",
+        "@material/mwc-floating-label": "^0.25.3",
+        "@material/mwc-icon": "^0.25.3",
+        "@material/mwc-line-ripple": "^0.25.3",
+        "@material/mwc-list": "^0.25.3",
+        "@material/mwc-menu": "^0.25.3",
+        "@material/mwc-notched-outline": "^0.25.3",
+        "@material/select": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
     "node_modules/@material/mwc-textfield": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/@material/mwc-textfield/-/mwc-textfield-0.25.3.tgz",
@@ -553,6 +574,30 @@
       "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
       "dependencies": {
         "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-r/D3e75H/sg+7iv+dkiyQ9cg8R6koHQJl85/gZqOlHpaQGSH5gSxpVeILkRY+ic6obQTdQCPRvUi9kzUve5zEg==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.261f2db59.0",
+        "@material/base": "14.0.0-canary.261f2db59.0",
+        "@material/density": "14.0.0-canary.261f2db59.0",
+        "@material/dom": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "@material/floating-label": "14.0.0-canary.261f2db59.0",
+        "@material/line-ripple": "14.0.0-canary.261f2db59.0",
+        "@material/list": "14.0.0-canary.261f2db59.0",
+        "@material/menu": "14.0.0-canary.261f2db59.0",
+        "@material/menu-surface": "14.0.0-canary.261f2db59.0",
+        "@material/notched-outline": "14.0.0-canary.261f2db59.0",
+        "@material/ripple": "14.0.0-canary.261f2db59.0",
+        "@material/rtl": "14.0.0-canary.261f2db59.0",
+        "@material/shape": "14.0.0-canary.261f2db59.0",
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "@material/typography": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
@@ -926,13 +971,15 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.1.0.tgz",
-      "integrity": "sha512-Y+dJGd5MPayWJM810Ni1hrSIunP/htTZgjF39NDVQ/ntWZAvNct3i4oR4jTo1BEb7TDgcHoiLfH5Do6oY4oD1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.2.0.tgz",
+      "integrity": "sha512-BZGhft9rJ6+6Vz78BWc9EBEAbvA7AZoV/ele/eVkRi2MO66t9dQL6stDKECjqH4okC6MDV79ShXsNsAeFTkxAA==",
       "dependencies": {
         "@material/mwc-button": "^0.25.3",
         "@material/mwc-circular-progress": "^0.25.3",
         "@material/mwc-dialog": "^0.25.3",
+        "@material/mwc-list": "^0.25.3",
+        "@material/mwc-select": "^0.25.3",
         "@material/mwc-textfield": "^0.25.3",
         "lit": "^2.0.0",
         "tslib": "^2.3.1"
@@ -1713,6 +1760,27 @@
         "tslib": "^2.0.1"
       }
     },
+    "@material/mwc-select": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-select/-/mwc-select-0.25.3.tgz",
+      "integrity": "sha512-mf1WrsNAW4rDHeVH+AgTPfNHAg70dJdwuIfIBqksAty3pYxnXQ9RjpL4Z/7kLdsGiS44du65vVgmZ63T0ifugQ==",
+      "requires": {
+        "@material/dom": "=14.0.0-canary.261f2db59.0",
+        "@material/floating-label": "=14.0.0-canary.261f2db59.0",
+        "@material/line-ripple": "=14.0.0-canary.261f2db59.0",
+        "@material/list": "=14.0.0-canary.261f2db59.0",
+        "@material/mwc-base": "^0.25.3",
+        "@material/mwc-floating-label": "^0.25.3",
+        "@material/mwc-icon": "^0.25.3",
+        "@material/mwc-line-ripple": "^0.25.3",
+        "@material/mwc-list": "^0.25.3",
+        "@material/mwc-menu": "^0.25.3",
+        "@material/mwc-notched-outline": "^0.25.3",
+        "@material/select": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
     "@material/mwc-textfield": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/@material/mwc-textfield/-/mwc-textfield-0.25.3.tgz",
@@ -1787,6 +1855,30 @@
       "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
       "requires": {
         "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@material/select": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-r/D3e75H/sg+7iv+dkiyQ9cg8R6koHQJl85/gZqOlHpaQGSH5gSxpVeILkRY+ic6obQTdQCPRvUi9kzUve5zEg==",
+      "requires": {
+        "@material/animation": "14.0.0-canary.261f2db59.0",
+        "@material/base": "14.0.0-canary.261f2db59.0",
+        "@material/density": "14.0.0-canary.261f2db59.0",
+        "@material/dom": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "@material/floating-label": "14.0.0-canary.261f2db59.0",
+        "@material/line-ripple": "14.0.0-canary.261f2db59.0",
+        "@material/list": "14.0.0-canary.261f2db59.0",
+        "@material/menu": "14.0.0-canary.261f2db59.0",
+        "@material/menu-surface": "14.0.0-canary.261f2db59.0",
+        "@material/notched-outline": "14.0.0-canary.261f2db59.0",
+        "@material/ripple": "14.0.0-canary.261f2db59.0",
+        "@material/rtl": "14.0.0-canary.261f2db59.0",
+        "@material/shape": "14.0.0-canary.261f2db59.0",
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "@material/typography": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
@@ -2106,13 +2198,15 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.1.0.tgz",
-      "integrity": "sha512-Y+dJGd5MPayWJM810Ni1hrSIunP/htTZgjF39NDVQ/ntWZAvNct3i4oR4jTo1BEb7TDgcHoiLfH5Do6oY4oD1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.2.0.tgz",
+      "integrity": "sha512-BZGhft9rJ6+6Vz78BWc9EBEAbvA7AZoV/ele/eVkRi2MO66t9dQL6stDKECjqH4okC6MDV79ShXsNsAeFTkxAA==",
       "requires": {
         "@material/mwc-button": "^0.25.3",
         "@material/mwc-circular-progress": "^0.25.3",
         "@material/mwc-dialog": "^0.25.3",
+        "@material/mwc-list": "^0.25.3",
+        "@material/mwc-select": "^0.25.3",
         "@material/mwc-textfield": "^0.25.3",
         "lit": "^2.0.0",
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@polymer/paper-tooltip": "^3.0.1",
     "@types/w3c-web-serial": "^1.0.2",
     "esp-web-flasher": "^5.0.0",
-    "improv-wifi-serial-sdk": "^2.1.0",
+    "improv-wifi-serial-sdk": "^2.2.0",
     "lit": "^2.1.2",
     "tslib": "^2.3.1"
   }


### PR DESCRIPTION
Adds support for picking SSIDs from a list of SSIDs.

Changelog: https://github.com/improv-wifi/sdk-serial-js/releases/tag/2.2.0