### PR TITLE
Allow downloading factory firmware

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -1,11 +1,13 @@
 import { fetchApiJson, fetchApiText, streamLogs } from ".";
 
+export type SupportedPlatforms = "ESP8266" | "ESP32" | "ESP32S2" | "ESP32C3";
+
 export interface CreateConfigParams {
   name: string;
   ssid: string;
   psk: string;
   board: string;
-  platform: "ESP8266" | "ESP32" | "ESP32S2" | "ESP32C3";
+  platform: SupportedPlatforms;
 }
 
 export interface Configuration {
@@ -16,13 +18,7 @@ export interface Configuration {
   src_version: number;
   arduino_version: string;
   address: string;
-  esp_platform:
-    | "ESP8266"
-    | "ESP32"
-    | "ESP32S2"
-    | "ESP32S3"
-    | "ESP32C3"
-    | "ESP32H2";
+  esp_platform: SupportedPlatforms;
   board: string;
   build_path: string;
   firmware_bin_path: string;

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -1,5 +1,6 @@
 import { fetchApiJson, fetchApiText } from ".";
 import { createPollingCollection } from "../util/polling-collection";
+import { SupportedPlatforms } from "./configuration";
 
 export interface ConfiguredDevice {
   name: string;
@@ -11,7 +12,7 @@ export interface ConfiguredDevice {
   comment: string;
   address: string;
   web_port: number;
-  target_platform: string;
+  target_platform: SupportedPlatforms;
 }
 
 export interface ImportableDevice {

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -25,6 +25,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
   @state() private _state:
     | "pick_option"
     | "web_instructions"
+    | "pick_download_type"
     | "pick_server_port" = "pick_option";
 
   @state() private _error?: string | TemplateResult;
@@ -75,12 +76,13 @@ class ESPHomeInstallChooseDialog extends LitElement {
         <mwc-list-item
           twoline
           hasMeta
-          dialogAction="close"
-          @click=${this._handleManualDownload}
+          @click=${() => {
+            this._state = "pick_download_type";
+          }}
         >
           <span>Manual download</span>
           <span slot="secondary">
-            Install it yourself using ESPHome Flasher or other tools
+            Install it yourself using ESPHome Web or other tools
           </span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -124,6 +126,49 @@ class ESPHomeInstallChooseDialog extends LitElement {
                 }}
               ></mwc-button>
             `;
+    } else if (this._state === "pick_download_type") {
+      heading = "What version do you want to download?";
+      content = html`
+        <mwc-list-item
+          twoline
+          hasMeta
+          dialogAction="close"
+          @click=${this._handleWebDownload}
+        >
+          <span>Modern format</span>
+          <span slot="secondary">
+            For use with ESPHome Web and other tools.
+          </span>
+          ${metaChevronRight}
+        </mwc-list-item>
+
+        <mwc-list-item
+          twoline
+          hasMeta
+          dialogAction="close"
+          @click=${this._handleManualDownload}
+        >
+          <span>Legacy format</span>
+          <span slot="secondary">For use with ESPHome Flasher.</span>
+          ${metaChevronRight}
+        </mwc-list-item>
+
+        <a
+          href="https://web.esphome.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bottom-left"
+          >Open ESPHome Web</a
+        >
+        <mwc-button
+          no-attention
+          slot="primaryAction"
+          label="Back"
+          @click=${() => {
+            this._state = "pick_option";
+          }}
+        ></mwc-button>
+      `;
     } else if (this._state === "web_instructions") {
       heading = "Install ESPHome via the browser";
       content = html`
@@ -393,6 +438,12 @@ class ESPHomeInstallChooseDialog extends LitElement {
       }
       ol {
         margin-bottom: 0;
+      }
+      a.bottom-left {
+        z-index: 1;
+        position: absolute;
+        line-height: 36px;
+        bottom: 9px;
       }
     `,
   ];


### PR DESCRIPTION
ESPHome offers 2 download formats for ESP32. This allows the user to pick which one they want to download:

![image](https://user-images.githubusercontent.com/1444314/155042830-0e760d46-c151-4e66-a0bf-52d29d5c05c2.png)
