### PR TITLE
Add UI support for RPi Pico-W

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -1,6 +1,11 @@
 import { fetchApiJson, fetchApiText, streamLogs } from ".";
 
-export type SupportedPlatforms = "ESP8266" | "ESP32" | "ESP32S2" | "ESP32C3";
+export type SupportedPlatforms =
+  | "ESP8266"
+  | "ESP32"
+  | "ESP32S2"
+  | "ESP32C3"
+  | "RP2040";
 
 export interface CreateConfigParams {
   name: string;

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -25,6 +25,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
   @property() public configuration!: string;
 
   @state() private _ethernet = false;
+  @state() private _platformSupportsWebSerial = true;
 
   @state() private _ports?: ServerSerialPort[];
 
@@ -63,10 +64,17 @@ class ESPHomeInstallChooseDialog extends LitElement {
 
         ${this._error ? html`<div class="error">${this._error}</div>` : ""}
 
-        <mwc-list-item twoline hasMeta @click=${this._handleBrowserInstall}>
+        <mwc-list-item
+          twoline
+          hasMeta
+          ?disabled=${!this._platformSupportsWebSerial}
+          @click=${this._handleBrowserInstall}
+        >
           <span>Plug into this computer</span>
           <span slot="secondary">
-            For devices connected via USB to this computer
+            ${this._platformSupportsWebSerial
+              ? "For devices connected via USB to this computer"
+              : "This platform does not support web installation"}
           </span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -88,7 +96,10 @@ class ESPHomeInstallChooseDialog extends LitElement {
         >
           <span>Manual download</span>
           <span slot="secondary">
-            Install it yourself using ESPHome Web or other tools
+            Install it yourself
+            ${this._platformSupportsWebSerial
+              ? "using ESPHome Web or other tools"
+              : ""}
           </span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -159,13 +170,17 @@ class ESPHomeInstallChooseDialog extends LitElement {
           ${metaChevronRight}
         </mwc-list-item>
 
-        <a
-          href="https://web.esphome.io"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="bottom-left"
-          >Open ESPHome Web</a
-        >
+        ${this._platformSupportsWebSerial
+          ? html`
+              <a
+                href="https://web.esphome.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="bottom-left"
+                >Open ESPHome Web</a
+              >
+            `
+          : ""}
         <mwc-button
           no-attention
           slot="primaryAction"
@@ -286,6 +301,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
     this._updateSerialPorts();
     getConfiguration(this.configuration).then((config) => {
       this._ethernet = config.loaded_integrations.includes("ethernet");
+      this._platformSupportsWebSerial = config.esp_platform !== "RP2040";
     });
   }
 

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -25,13 +25,13 @@ class ESPHomeInstallChooseDialog extends LitElement {
   @property() public configuration!: string;
 
   @state() private _ethernet = false;
-  @state() private _platformSupportsWebSerial = true;
+  @state() private _isPico = false;
 
   @state() private _ports?: ServerSerialPort[];
 
   @state() private _state:
     | "pick_option"
-    | "web_instructions"
+    | "download_instructions"
     | "pick_download_type"
     | "pick_server_port" = "pick_option";
 
@@ -42,6 +42,10 @@ class ESPHomeInstallChooseDialog extends LitElement {
   private _compileConfiguration?: Promise<unknown>;
 
   private _abortCompilation?: AbortController;
+
+  private get _platformSupportsWebSerial() {
+    return !this._isPico;
+  }
 
   protected render() {
     let heading;
@@ -79,7 +83,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
           ${metaChevronRight}
         </mwc-list-item>
 
-        <mwc-list-item twoline hasMeta @click=${this._showServerPorts}>
+        <mwc-list-item twoline hasMeta @click=${this._handleServerInstall}>
           <span>Plug into the computer running ESPHome Dashboard</span>
           <span slot="secondary">
             For devices connected via USB to the server
@@ -91,15 +95,17 @@ class ESPHomeInstallChooseDialog extends LitElement {
           twoline
           hasMeta
           @click=${() => {
-            this._state = "pick_download_type";
+            this._state = this._isPico
+              ? "download_instructions"
+              : "pick_download_type";
           }}
         >
           <span>Manual download</span>
           <span slot="secondary">
             Install it yourself
-            ${this._platformSupportsWebSerial
-              ? "using ESPHome Web or other tools"
-              : ""}
+            ${this._isPico
+              ? "by dragging it to the Pico USB drive"
+              : "using ESPHome Web or other tools"}
           </span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -116,24 +122,33 @@ class ESPHomeInstallChooseDialog extends LitElement {
       content =
         this._ports === undefined
           ? this._renderProgress("Loading serial devices")
-          : this._ports.length === 0
-          ? this._renderMessage(WARNING_ICON, "No serial devices found.", true)
           : html`
-              ${this._ports.map(
-                (port) => html`
-                  <mwc-list-item
-                    twoline
-                    hasMeta
-                    .port=${port.port}
-                    @click=${this._handleLegacyOption}
-                  >
-                    <span>${port.desc}</span>
-                    <span slot="secondary">${port.port}</span>
-                    ${metaChevronRight}
-                  </mwc-list-item>
-                `
-              )}
-
+              ${this._ports.length === 0
+                ? this._renderMessage(
+                    WARNING_ICON,
+                    html`
+                      No serial devices found.
+                      <br /><br />
+                      This list automatically refreshes if you plug one in.
+                    `,
+                    false
+                  )
+                : html`
+                    ${this._ports.map(
+                      (port) => html`
+                        <mwc-list-item
+                          twoline
+                          hasMeta
+                          .port=${port.port}
+                          @click=${this._handleLegacyOption}
+                        >
+                          <span>${port.desc}</span>
+                          <span slot="secondary">${port.port}</span>
+                          ${metaChevronRight}
+                        </mwc-list-item>
+                      `
+                    )}
+                  `}
               <mwc-button
                 no-attention
                 slot="primaryAction"
@@ -190,41 +205,65 @@ class ESPHomeInstallChooseDialog extends LitElement {
           }}
         ></mwc-button>
       `;
-    } else if (this._state === "web_instructions") {
-      heading = "Install ESPHome via the browser";
+    } else if (this._state === "download_instructions") {
+      let instructions: TemplateResult;
+      const downloadButton = until(
+        this._compileConfiguration,
+        html`<a download disabled href="#">Download project</a>
+          preparing&nbsp;download…
+          <mwc-circular-progress
+            density="-8"
+            indeterminate
+          ></mwc-circular-progress>`
+      );
+
+      if (this._isPico) {
+        heading = "Install ESPHome via the USB drive";
+        instructions = html`
+          <div>
+            You can install your ESPHome project ${this.configuration} on your
+            device via your file explorer by following these steps:
+          </div>
+          <ol>
+            <li>Disconnect your Raspberry Pi Pico from your computer</li>
+            <li>
+              Hold the BOOTSEL button and connect the Pico to your computer
+            </li>
+            <li>The Pico will show up as a USB drive named RPI-RP2</li>
+            <li>${downloadButton}</li>
+            <li>Drag the downloaded file to the USB drive</li>
+            <li>Your Pico will reboot and the installation is complete</li>
+          </ol>
+        `;
+      } else {
+        heading = "Install ESPHome via the browser";
+        instructions = html`
+          <div>
+            ESPHome can install ${this.configuration} on your device via the
+            browser if certain requirements are met:
+          </div>
+          <ul>
+            <li>ESPHome is visited over HTTPS</li>
+            <li>Your browser supports WebSerial</li>
+          </ul>
+          <div>
+            Not all requirements are currently met. The easiest solution is to
+            download your project and do the installation with ESPHome Web.
+            ESPHome Web works 100% in your browser and no data will be shared
+            with the ESPHome project.
+          </div>
+          <ol>
+            <li>${downloadButton}</li>
+            <li>
+              <a href=${ESPHOME_WEB_URL} target="_blank" rel="noopener"
+                >Open ESPHome Web</a
+              >
+            </li>
+          </ol>
+        `;
+      }
       content = html`
-        <div>
-          ESPHome can install ${this.configuration} on your device via the
-          browser if certain requirements are met:
-        </div>
-        <ul>
-          <li>ESPHome is visited over HTTPS</li>
-          <li>Your browser supports WebSerial</li>
-        </ul>
-        <div>
-          Not all requirements are currently met. The easiest solution is to
-          download your project and do the installation with ESPHome Web.
-          ESPHome Web works 100% in your browser and no data will be shared with
-          the ESPHome project.
-        </div>
-        <ol>
-          <li>
-            ${until(
-              this._compileConfiguration,
-              html`<a download disabled href="#">Download project</a>
-                preparing&nbsp;download…
-                <mwc-circular-progress
-                  density="-8"
-                  indeterminate
-                ></mwc-circular-progress>`
-            )}
-          </li>
-          <li>
-            <a href=${ESPHOME_WEB_URL} target="_blank" rel="noopener"
-              >Open ESPHome Web</a
-            >
-          </li>
-        </ol>
+        ${instructions}
 
         <mwc-button
           no-attention
@@ -233,12 +272,6 @@ class ESPHomeInstallChooseDialog extends LitElement {
           @click=${() => {
             this._state = "pick_option";
           }}
-        ></mwc-button>
-        <mwc-button
-          no-attention
-          slot="primaryAction"
-          dialogAction="close"
-          label="Close"
         ></mwc-button>
       `;
     }
@@ -285,14 +318,15 @@ class ESPHomeInstallChooseDialog extends LitElement {
         <div class="icon">${icon}</div>
         ${label}
       </div>
-      ${showClose &&
-      html`
-        <mwc-button
-          slot="primaryAction"
-          dialogAction="ok"
-          label="Close"
-        ></mwc-button>
-      `}
+      ${showClose
+        ? html`
+            <mwc-button
+              slot="primaryAction"
+              dialogAction="ok"
+              label="Close"
+            ></mwc-button>
+          `
+        : ""}
     `;
   }
 
@@ -301,7 +335,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
     this._updateSerialPorts();
     getConfiguration(this.configuration).then((config) => {
       this._ethernet = config.loaded_integrations.includes("ethernet");
-      this._platformSupportsWebSerial = config.esp_platform !== "RP2040";
+      this._isPico = config.esp_platform === "RP2040";
     });
   }
 
@@ -313,14 +347,16 @@ class ESPHomeInstallChooseDialog extends LitElement {
     super.willUpdate(changedProps);
     if (
       changedProps.has("_state") &&
-      this._state === "web_instructions" &&
+      this._state === "download_instructions" &&
       !this._compileConfiguration
     ) {
       this._abortCompilation = new AbortController();
       this._compileConfiguration = compileConfiguration(this.configuration)
         .then(
           () => html`
-            <a download href="${getDownloadUrl(this.configuration, true)}"
+            <a
+              download
+              href="${getDownloadUrl(this.configuration, !this._isPico)}"
               >Download project</a
             >
           `,
@@ -330,7 +366,9 @@ class ESPHomeInstallChooseDialog extends LitElement {
             <button
               class="link"
               dialogAction="close"
-              @click=${this._handleWebDownload}
+              @click=${() => {
+                openCompileDialog(this.configuration, !this._isPico);
+              }}
             >
               see what went wrong
             </button>
@@ -369,7 +407,12 @@ class ESPHomeInstallChooseDialog extends LitElement {
     );
   }
 
-  private _showServerPorts() {
+  private _handleServerInstall() {
+    if (this._isPico) {
+      openInstallServerDialog(this.configuration, "LOCAL");
+      this._close();
+      return;
+    }
     this._storeDialogWidth();
     this._state = "pick_server_port";
   }
@@ -390,7 +433,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
   private _handleBrowserInstall() {
     if (!supportsWebSerial || !allowsWebSerial) {
       this._storeDialogWidth();
-      this._state = "web_instructions";
+      this._state = "download_instructions";
       return;
     }
 
@@ -452,6 +495,13 @@ class ESPHomeInstallChooseDialog extends LitElement {
       }
       .prepare-error {
         color: var(--alert-error-color);
+      }
+      ul,
+      ol {
+        padding-left: 24px;
+      }
+      li {
+        line-height: 2em;
       }
       li a {
         display: inline-block;

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -78,15 +78,22 @@ class ESPHomeInstallChooseDialog extends LitElement {
           <span slot="secondary">
             ${this._platformSupportsWebSerial
               ? "For devices connected via USB to this computer"
-              : "This platform does not support web installation"}
+              : "Installing this via the web is not supported yet for this device"}
           </span>
           ${metaChevronRight}
         </mwc-list-item>
 
-        <mwc-list-item twoline hasMeta @click=${this._handleServerInstall}>
+        <mwc-list-item
+          twoline
+          hasMeta
+          ?disabled=${this._isPico}
+          @click=${this._handleServerInstall}
+        >
           <span>Plug into the computer running ESPHome Dashboard</span>
           <span slot="secondary">
-            For devices connected via USB to the server
+            ${this._isPico
+              ? "Installing this from the server is not supported yet for this device"
+              : "For devices connected via USB to the server"}
           </span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -104,7 +111,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
           <span slot="secondary">
             Install it yourself
             ${this._isPico
-              ? "by dragging it to the Pico USB drive"
+              ? "by copying it to the Pico USB drive"
               : "using ESPHome Web or other tools"}
           </span>
           ${metaChevronRight}
@@ -408,11 +415,6 @@ class ESPHomeInstallChooseDialog extends LitElement {
   }
 
   private _handleServerInstall() {
-    if (this._isPico) {
-      openInstallServerDialog(this.configuration, "LOCAL");
-      this._close();
-      return;
-    }
     this._storeDialogWidth();
     this._state = "pick_server_port";
   }

--- a/src/logs-webserial/logs-webserial-dialog.ts
+++ b/src/logs-webserial/logs-webserial-dialog.ts
@@ -1,5 +1,5 @@
-import { LitElement, html, css } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { LitElement, html, css, PropertyValues } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
 import "@material/mwc-dialog";
 import "@material/mwc-button";
 import "./ewt-console";
@@ -7,6 +7,7 @@ import { textDownload } from "../util/file-download";
 import type { EwtConsole } from "./ewt-console";
 import { basename } from "../util/basename";
 import { openEditDialog } from "../editor";
+import { getConfiguration } from "../api/configuration";
 
 @customElement("esphome-logs-webserial-dialog")
 class ESPHomeLogsWebSerialDialog extends LitElement {
@@ -17,6 +18,8 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
   @property() public closePortOnClose!: boolean;
 
   @query("ewt-console") private _console!: EwtConsole;
+
+  @state() private _isPico = false;
 
   protected render() {
     return html`
@@ -46,11 +49,15 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
               ></mwc-button>
             `
           : ""}
-        <mwc-button
-          slot="secondaryAction"
-          label="Reset Device"
-          @click=${this._resetDevice}
-        ></mwc-button>
+        ${this._isPico
+          ? ""
+          : html`
+              <mwc-button
+                slot="secondaryAction"
+                label="Reset Device"
+                @click=${this._resetDevice}
+              ></mwc-button>
+            `}
         <mwc-button
           slot="primaryAction"
           dialogAction="close"
@@ -58,6 +65,15 @@ class ESPHomeLogsWebSerialDialog extends LitElement {
         ></mwc-button>
       </mwc-dialog>
     `;
+  }
+
+  protected firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
+    if (this.configuration) {
+      getConfiguration(this.configuration).then((config) => {
+        this._isPico = config.esp_platform === "RP2040";
+      });
+    }
   }
 
   private async _openEdit() {

--- a/src/wizard/boards.ts
+++ b/src/wizard/boards.ts
@@ -21,8 +21,8 @@ export const boardSelectOptions = html`
     <option value="thingdev">Sparkfun ESP8266 Thing - Dev Board</option>
   </optgroup>
   <optgroup label="Raspberry Pi">
-    <option value="rpi_pico">Raspberry Pi Pico</option>
-    <option value="rpi_picow">Raspberry Pi Pico W</option>
+    <option value="rpipico">Raspberry Pi Pico</option>
+    <option value="rpipicow">Raspberry Pi Pico W</option>
   </optgroup>
   <optgroup label="Other ESP8266s">
     <option value="gen4iod">4D Systems gen4 IoD Range</option>

--- a/src/wizard/boards.ts
+++ b/src/wizard/boards.ts
@@ -20,6 +20,10 @@ export const boardSelectOptions = html`
     <option value="thing">Sparkfun ESP8266 Thing</option>
     <option value="thingdev">Sparkfun ESP8266 Thing - Dev Board</option>
   </optgroup>
+  <optgroup label="Raspberry Pi">
+    <option value="rpi_pico">Raspberry Pi Pico</option>
+    <option value="rpi_picow">Raspberry Pi Pico W</option>
+  </optgroup>
   <optgroup label="Other ESP8266s">
     <option value="gen4iod">4D Systems gen4 IoD Range</option>
     <option value="wifi_slot">Amperka WiFi Slot</option>

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -52,6 +52,7 @@ const BOARD_GENERIC_ESP32 = "esp32dev";
 const BOARD_GENERIC_ESP8266 = "esp01_1m";
 const BOARD_GENERIC_ESP32S2 = "esp32-s2-saola-1";
 const BOARD_GENERIC_ESP32C3 = "esp32-c3-devkitm-1";
+const BOARD_RPI_PICO_W = "rpi_picow";
 
 @customElement("esphome-wizard-dialog")
 export class ESPHomeWizardDialog extends LitElement {
@@ -62,6 +63,7 @@ export class ESPHomeWizardDialog extends LitElement {
     | typeof BOARD_GENERIC_ESP8266
     | typeof BOARD_GENERIC_ESP32S2
     | typeof BOARD_GENERIC_ESP32C3
+    | typeof BOARD_RPI_PICO_W
     | "CUSTOM" = BOARD_GENERIC_ESP32;
 
   // undefined = not loaded
@@ -357,6 +359,15 @@ export class ESPHomeWizardDialog extends LitElement {
         ></mwc-radio>
       </mwc-formfield>
 
+      <mwc-formfield label="Raspberry Pi Pico W">
+        <mwc-radio
+          name="board"
+          .value=${BOARD_RPI_PICO_W}
+          @click=${this._handlePickBoardRadio}
+          ?checked=${this._board === BOARD_RPI_PICO_W}
+        ></mwc-radio>
+      </mwc-formfield>
+
       <mwc-formfield label="Pick specific board">
         <mwc-radio
           name="board"
@@ -403,8 +414,9 @@ export class ESPHomeWizardDialog extends LitElement {
       </div>
 
       <div>
-        Connect your ESP board with a USB cable to your computer and click on
-        connect. You need to do this once. Later updates install wirelessly.
+        Connect your ESP8266 or ESP32 with a USB cable to your computer and
+        click on connect. You need to do this once. Later updates install
+        wirelessly.
         <a
           href="https://esphome.io/guides/getting_started_hassio.html#webserial"
           target="_blank"
@@ -412,7 +424,10 @@ export class ESPHomeWizardDialog extends LitElement {
         >
       </div>
 
-      <div>Skip this step to install it on your device later.</div>
+      <div>
+        Skip this step to install it on your device later or if you are using a
+        Raspberry Pi Pico.
+      </div>
 
       <mwc-button
         slot="primaryAction"

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -52,7 +52,7 @@ const BOARD_GENERIC_ESP32 = "esp32dev";
 const BOARD_GENERIC_ESP8266 = "esp01_1m";
 const BOARD_GENERIC_ESP32S2 = "esp32-s2-saola-1";
 const BOARD_GENERIC_ESP32C3 = "esp32-c3-devkitm-1";
-const BOARD_RPI_PICO_W = "rpi_picow";
+const BOARD_RPI_PICO_W = "rpipicow";
 
 @customElement("esphome-wizard-dialog")
 export class ESPHomeWizardDialog extends LitElement {


### PR DESCRIPTION
~~This is a draft while we wait for the backend.~~ Requires https://github.com/esphome/esphome/pull/3284

### Wizard - Web Installation step now mentions to skip step if it's a Raspberry Pi Pico

![image](https://user-images.githubusercontent.com/1444314/176789719-40c3692d-c939-4192-9638-737f5d5ea854.png)

### Wizard - Select device type shows Pico W as option

![image](https://user-images.githubusercontent.com/1444314/176789764-85b578d7-d457-40c8-a332-9c8865e2a7f6.png)

- Pick specific board also allows choosing the normal Pico
  ![image](https://user-images.githubusercontent.com/1444314/176789802-77acad71-2d21-4022-97cb-7a7c1008243c.png)

### Install choose dialog - The web installation option is disabled

![image](https://user-images.githubusercontent.com/1444314/176789865-37b20bb9-8d6d-47ca-a677-2b98e303e225.png)


