### PR TITLE
Clean up board picker logic

### DIFF
--- a/src/wizard/boards.ts
+++ b/src/wizard/boards.ts
@@ -1,6 +1,14 @@
 import { html } from "lit";
 
 export const boardSelectOptions = html`
+  <optgroup label="ESP32">
+    <option value="esp-wrover-kit">Generic ESP32 (WROVER Module)</option>
+    <option value="nodemcu-32s">NodeMCU-32S</option>
+    <option value="lolin_d32">Wemos Lolin D32</option>
+    <option value="lolin_d32_pro">Wemos Lolin D32 Pro</option>
+    <option value="featheresp32">Adafruit ESP32 Feather</option>
+    <option value="m5stack-core-esp32">M5Stack Core ESP32</option>
+  </optgroup>
   <optgroup label="ESP8266">
     <option value="esp01_1m">Generic ESP8266 (for example Sonoff)</option>
     <option value="nodemcuv2">NodeMCU</option>
@@ -11,14 +19,6 @@ export const boardSelectOptions = html`
     <option value="oak">DigiStump Oak</option>
     <option value="thing">Sparkfun ESP8266 Thing</option>
     <option value="thingdev">Sparkfun ESP8266 Thing - Dev Board</option>
-  </optgroup>
-  <optgroup label="ESP32">
-    <option value="esp-wrover-kit">Generic ESP32 (WROVER Module)</option>
-    <option value="nodemcu-32s">NodeMCU-32S</option>
-    <option value="lolin_d32">Wemos Lolin D32</option>
-    <option value="lolin_d32_pro">Wemos Lolin D32 Pro</option>
-    <option value="featheresp32">Adafruit ESP32 Feather</option>
-    <option value="m5stack-core-esp32">M5Stack Core ESP32</option>
   </optgroup>
   <optgroup label="Other ESP8266s">
     <option value="gen4iod">4D Systems gen4 IoD Range</option>

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -48,21 +48,21 @@ https://docs.google.com/drawings/d/1LAYImcreQdcUxtBt10K76FFypMGRTwu1tGBEERfAWkE/
 
 */
 
-const GENERIC_ESP32 = "esp32dev";
-const GENERIC_ESP8266 = "esp01_1m";
-const GENERIC_ESP32S2 = "esp32-s2-saola-1";
-const GENERIC_ESP32C3 = "esp32-c3-devkitm-1";
+const BOARD_GENERIC_ESP32 = "esp32dev";
+const BOARD_GENERIC_ESP8266 = "esp01_1m";
+const BOARD_GENERIC_ESP32S2 = "esp32-s2-saola-1";
+const BOARD_GENERIC_ESP32C3 = "esp32-c3-devkitm-1";
 
 @customElement("esphome-wizard-dialog")
 export class ESPHomeWizardDialog extends LitElement {
   @state() private _busy = false;
 
   @state() private _board:
-    | "ESP32"
-    | "ESP8266"
-    | "ESP32S2"
-    | "ESP32C3"
-    | "CUSTOM" = "ESP32";
+    | typeof BOARD_GENERIC_ESP32
+    | typeof BOARD_GENERIC_ESP8266
+    | typeof BOARD_GENERIC_ESP32S2
+    | typeof BOARD_GENERIC_ESP32C3
+    | "CUSTOM" = BOARD_GENERIC_ESP32;
 
   // undefined = not loaded
   @state() private _hasWifiSecrets: undefined | boolean = undefined;
@@ -126,7 +126,9 @@ export class ESPHomeWizardDialog extends LitElement {
               html`
                 Installing<br /><br />
                 This will take
-                ${this._board === "ESP8266" ? "a minute" : "2 minutes"}.<br />
+                ${this._board === BOARD_GENERIC_ESP8266
+                  ? "a minute"
+                  : "2 minutes"}.<br />
                 Keep this page visible to prevent slow down
               `,
               // Show as undeterminate under 3% or else we don't show any pixels
@@ -322,36 +324,36 @@ export class ESPHomeWizardDialog extends LitElement {
       <mwc-formfield label="ESP32" checked>
         <mwc-radio
           name="board"
-          value="ESP32"
+          .value=${BOARD_GENERIC_ESP32}
           @click=${this._handlePickBoardRadio}
-          ?checked=${this._board === "ESP32"}
+          ?checked=${this._board === BOARD_GENERIC_ESP32}
         ></mwc-radio>
       </mwc-formfield>
 
       <mwc-formfield label="ESP32-S2">
         <mwc-radio
           name="board"
-          value="ESP32S2"
+          .value=${BOARD_GENERIC_ESP32S2}
           @click=${this._handlePickBoardRadio}
-          ?checked=${this._board === "ESP32S2"}
+          ?checked=${this._board === BOARD_GENERIC_ESP32S2}
         ></mwc-radio>
       </mwc-formfield>
 
       <mwc-formfield label="ESP32-C3">
         <mwc-radio
           name="board"
-          value="ESP32C3"
+          .value=${BOARD_GENERIC_ESP32C3}
           @click=${this._handlePickBoardRadio}
-          ?checked=${this._board === "ESP32C3"}
+          ?checked=${this._board === BOARD_GENERIC_ESP32C3}
         ></mwc-radio>
       </mwc-formfield>
 
       <mwc-formfield label="ESP8266">
         <mwc-radio
           name="board"
-          value="ESP8266"
+          .value=${BOARD_GENERIC_ESP8266}
           @click=${this._handlePickBoardRadio}
-          ?checked=${this._board === "ESP8266"}
+          ?checked=${this._board === BOARD_GENERIC_ESP8266}
         ></mwc-radio>
       </mwc-formfield>
 
@@ -556,21 +558,8 @@ export class ESPHomeWizardDialog extends LitElement {
   }
 
   private async _handlePickBoardSubmit() {
-    if (this._board === "ESP32") {
-      this._data.platform = "ESP32";
-      this._data.board = GENERIC_ESP32;
-    } else if (this._board === "ESP8266") {
-      this._data.platform = "ESP8266";
-      this._data.board = GENERIC_ESP8266;
-    } else if (this._board === "ESP32S2") {
-      this._data.platform = "ESP32S2";
-      this._data.board = GENERIC_ESP32S2;
-    } else if (this._board === "ESP32C3") {
-      this._data.platform = "ESP32C3";
-      this._data.board = GENERIC_ESP32C3;
-    } else {
-      this._data.board = this._customBoard;
-    }
+    this._data.board =
+      this._board === "CUSTOM" ? this._customBoard : this._board;
 
     this._busy = true;
 
@@ -626,19 +615,13 @@ export class ESPHomeWizardDialog extends LitElement {
       this._state = "prepare_flash";
 
       if (esploader.chipFamily === CHIP_FAMILY_ESP32) {
-        this._board = "ESP32";
-        this._data.board = GENERIC_ESP32;
+        this._data.board = BOARD_GENERIC_ESP32;
       } else if (esploader.chipFamily === CHIP_FAMILY_ESP8266) {
-        this._board = "ESP8266";
-        this._data.board = GENERIC_ESP8266;
+        this._data.board = BOARD_GENERIC_ESP8266;
       } else if (esploader.chipFamily === CHIP_FAMILY_ESP32S2) {
-        this._board = "ESP32S2";
-        this._data.board = GENERIC_ESP32S2;
-        this._data.platform = "ESP32S2";
+        this._data.board = BOARD_GENERIC_ESP32S2;
       } else if (esploader.chipFamily === CHIP_FAMILY_ESP32C3) {
-        this._board = "ESP32C3";
-        this._data.board = GENERIC_ESP32C3;
-        this._data.platform = "ESP32C3";
+        this._data.board = BOARD_GENERIC_ESP32C3;
       } else {
         this._state = "connect_webserial";
         this._error = `Unable to identify the connected device (${esploader.chipFamily}).`;


### PR DESCRIPTION
In #265 realized the code could use some cleanup so doing that here. 

- Moved ESP32 up in generic boards
- Removed intermediate custom values when picking a board and replaced with constants.