### PR TITLE
Add show API key dialog

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -19,6 +19,7 @@ import { fireEvent } from "../util/fire-event";
 import { openDeleteDeviceDialog } from "../delete-device";
 import { esphomeCardStyles } from "../styles";
 import { openRenameDialog } from "../rename";
+import { openShowApiKeyDialog } from "../show-api-key";
 
 const UPDATE_TO_ICON = "➡️";
 const STATUS_COLORS = {
@@ -129,6 +130,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
             <mwc-icon-button slot="trigger" icon="more_vert"></mwc-icon-button>
             <mwc-list-item>Validate</mwc-list-item>
             <mwc-list-item>Install</mwc-list-item>
+            <mwc-list-item>Show API key</mwc-list-item>
             <mwc-list-item>Rename</mwc-list-item>
             <mwc-list-item>Clean Build Files</mwc-list-item>
             <mwc-list-item>Delete</mwc-list-item>
@@ -186,19 +188,22 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
         this._handleInstall();
         break;
       case 2:
-        openRenameDialog(this.device.configuration, this.device.name);
+        openShowApiKeyDialog(this.device.configuration);
         break;
       case 3:
-        openCleanDialog(this.device.configuration);
+        openRenameDialog(this.device.configuration, this.device.name);
         break;
       case 4:
+        openCleanDialog(this.device.configuration);
+        break;
+      case 5:
         openDeleteDeviceDialog(
           this.device.name,
           this.device.configuration,
           () => fireEvent(this, "deleted")
         );
         break;
-      case 5:
+      case 6:
         openCleanMQTTDialog(this.device.configuration);
         break;
     }

--- a/src/show-api-key/index.ts
+++ b/src/show-api-key/index.ts
@@ -1,0 +1,8 @@
+const preload = () => import("./show-api-key-dialog");
+
+export const openShowApiKeyDialog = (configuration: string) => {
+  preload();
+  const dialog = document.createElement("esphome-show-api-key-dialog");
+  dialog.configuration = configuration;
+  document.body.append(dialog);
+};

--- a/src/show-api-key/show-api-key-dialog.ts
+++ b/src/show-api-key/show-api-key-dialog.ts
@@ -1,0 +1,128 @@
+import { LitElement, html, css, PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import "@material/mwc-button";
+import "@material/mwc-dialog";
+import { esphomeDialogStyles } from "../styles";
+import { getFile } from "../api/files";
+import { openEditDialog } from "../legacy";
+import { copyToClipboard } from "../util/copy-clipboard";
+
+const API_KEY_START = `api:
+  encryption:
+    key: "`;
+
+@customElement("esphome-show-api-key-dialog")
+class ESPHomeShowApiKeyDialogDialog extends LitElement {
+  @property() public configuration!: string;
+
+  @state() private _apiKey?: string | null;
+
+  @state() private _showCopied = false;
+
+  protected render() {
+    return html`
+      <mwc-dialog
+        open
+        heading=${`API key for ${this.configuration}`}
+        scrimClickAction
+        @closed=${this._handleClose}
+      >
+        ${this._apiKey === undefined
+          ? "Loading…"
+          : this._apiKey === null
+          ? html`Unable to automatically extract API key. Open the configuration
+              and look for <code>api:</code>.`
+          : html`
+              <div class="key" @click=${this._copyApiKey}>
+                <code>${this._apiKey}</code>
+                <mwc-button ?disabled=${this._showCopied}
+                  >${this._showCopied ? "Copied!" : "Copy"}</mwc-button
+                >
+              </div>
+            `}
+        ${this._apiKey === null
+          ? html`
+              <mwc-button
+                @click=${this._editConfig}
+                no-attention
+                slot="secondaryAction"
+                dialogAction="close"
+                label="Open configuration"
+              ></mwc-button>
+            `
+          : ""}
+
+        <mwc-button
+          no-attention
+          slot="primaryAction"
+          dialogAction="close"
+          label="Close"
+        ></mwc-button>
+      </mwc-dialog>
+    `;
+  }
+
+  protected firstUpdated(changedProps: PropertyValues): void {
+    super.firstUpdated(changedProps);
+    getFile(this.configuration).then(async (content) => {
+      if (!content) {
+        this._apiKey = null;
+        return;
+      }
+      let start = content.indexOf(API_KEY_START);
+      if (start === -1) {
+        this._apiKey = null;
+      } else {
+        start += API_KEY_START.length;
+        this._apiKey = content.substring(start, content.indexOf('"', start));
+      }
+    });
+  }
+
+  private _copyApiKey() {
+    copyToClipboard(this._apiKey!);
+    this._showCopied = true;
+    setTimeout(() => (this._showCopied = false), 2000);
+  }
+
+  private _editConfig() {
+    openEditDialog(this.configuration);
+  }
+
+  private _handleClose() {
+    this.parentNode!.removeChild(this);
+  }
+
+  static styles = [
+    esphomeDialogStyles,
+    css`
+      .key {
+        position: relative;
+        display: flex;
+        align-items: center;
+      }
+      code {
+        word-break: break-all;
+      }
+      .key mwc-button {
+        margin-left: 16px;
+      }
+      .copied {
+        font-weight: bold;
+        color: var(--alert-success-color);
+
+        position: absolute;
+        background-color: var(--mdc-theme-surface, #fff);
+        padding: 10px;
+        right: 0;
+        font-size: 1.2em;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-show-api-key-dialog": ESPHomeShowApiKeyDialogDialog;
+  }
+}

--- a/src/util/copy-clipboard.ts
+++ b/src/util/copy-clipboard.ts
@@ -1,0 +1,17 @@
+export const copyToClipboard = async (str: string) => {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(str);
+      return;
+    } catch {
+      // just continue with the fallback coding below
+    }
+  }
+
+  const el = document.createElement("textarea");
+  el.value = str;
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand("copy");
+  document.body.removeChild(el);
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1444314/177060814-5b9b38f3-f7f8-4196-b476-09f363435716.png)

Dialog has 2 states, key found and key not found:

![image](https://user-images.githubusercontent.com/1444314/177060826-346e079f-b4fe-4e2f-83ce-5e76bf3708b6.png)

![image](https://user-images.githubusercontent.com/1444314/177060846-1130dc6a-7f7b-4c95-b5f6-b9868d04e0b8.png)

Tapping the key or the copy button copies the key to the clipboard and shows this for 2 seconds:

![image](https://user-images.githubusercontent.com/1444314/177060859-6bfdbeb2-600a-4c12-b52c-9bd4fd3df878.png)
