### PR TITLE
Add a download dialog

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -20,6 +20,7 @@ import { esphomeCardStyles } from "../styles";
 import { openRenameDialog } from "../rename";
 import { openShowApiKeyDialog } from "../show-api-key";
 import { openEditDialog } from "../editor";
+import { openDownloadChooseDialog } from "../download-choose";
 
 const UPDATE_TO_ICON = "➡️";
 const STATUS_COLORS = {
@@ -130,6 +131,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
             <mwc-icon-button slot="trigger" icon="more_vert"></mwc-icon-button>
             <mwc-list-item>Validate</mwc-list-item>
             <mwc-list-item>Install</mwc-list-item>
+            <mwc-list-item>Download</mwc-list-item>
             <mwc-list-item>Show API key</mwc-list-item>
             <mwc-list-item>Rename</mwc-list-item>
             <mwc-list-item>Clean Build Files</mwc-list-item>
@@ -188,22 +190,25 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
         this._handleInstall();
         break;
       case 2:
-        openShowApiKeyDialog(this.device.configuration);
+        openDownloadChooseDialog(this.device.configuration);
         break;
       case 3:
-        openRenameDialog(this.device.configuration, this.device.name);
+        openShowApiKeyDialog(this.device.configuration);
         break;
       case 4:
-        openCleanDialog(this.device.configuration);
+        openRenameDialog(this.device.configuration, this.device.name);
         break;
       case 5:
+        openCleanDialog(this.device.configuration);
+        break;
+      case 6:
         openDeleteDeviceDialog(
           this.device.name,
           this.device.configuration,
           () => fireEvent(this, "deleted")
         );
         break;
-      case 6:
+      case 7:
         openCleanMQTTDialog(this.device.configuration);
         break;
     }

--- a/src/download-choose/download-choose-dialog.ts
+++ b/src/download-choose/download-choose-dialog.ts
@@ -1,0 +1,121 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import "@material/mwc-dialog";
+import "@material/mwc-list/mwc-list-item.js";
+import "@material/mwc-circular-progress";
+import "@material/mwc-button";
+import { metaChevronRight } from "../const";
+import { openCompileDialog } from "../compile";
+import { esphomeDialogStyles } from "../styles";
+import { textDownload } from "../util/file-download";
+import { getFile } from "../api/files";
+
+const ESPHOME_WEB_URL = "https://web.esphome.io/?dashboard_install";
+
+@customElement("esphome-download-choose-dialog")
+class ESPHomeDownloadChooseDialog extends LitElement {
+  @property() public configuration!: string;
+
+  protected render() {
+    return html`
+      <mwc-dialog
+        open
+        .heading=${this.configuration}
+        @closed=${this._handleClose}
+      >
+        <mwc-list-item
+          twoline
+          hasMeta
+          dialogAction="close"
+          @click=${this._handleYamlDownload}
+        >
+          <span>Download YAML</span>
+          <span slot="secondary">
+            Download as local backup or share with friends and family
+          </span>
+          ${metaChevronRight}
+        </mwc-list-item>
+
+        <mwc-list-item
+          twoline
+          hasMeta
+          dialogAction="close"
+          @click=${this._handleWebDownload}
+        >
+          <span>Download compiled binary</span>
+          <span slot="secondary">
+            To install using ESPHome Web and other tools.
+          </span>
+          ${metaChevronRight}
+        </mwc-list-item>
+
+        <mwc-list-item
+          twoline
+          hasMeta
+          dialogAction="close"
+          @click=${this._handleManualDownload}
+        >
+          <span>Download compiled binary (legacy format)</span>
+          <span slot="secondary">For use with ESPHome Flasher.</span>
+          ${metaChevronRight}
+        </mwc-list-item>
+
+        <a
+          href=${ESPHOME_WEB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bottom-left"
+          >Open ESPHome Web</a
+        >
+        <mwc-button
+          no-attention
+          slot="secondaryAction"
+          dialogAction="close"
+          label="Cancel"
+        ></mwc-button>
+      </mwc-dialog>
+    `;
+  }
+
+  private _handleYamlDownload() {
+    getFile(this.configuration).then((config) => {
+      textDownload(config!, this.configuration);
+    });
+  }
+
+  private _handleManualDownload() {
+    openCompileDialog(this.configuration, false);
+  }
+
+  private _handleWebDownload() {
+    openCompileDialog(this.configuration, true);
+  }
+
+  private async _handleClose() {
+    this.parentNode!.removeChild(this);
+  }
+
+  static styles = [
+    esphomeDialogStyles,
+    css`
+      mwc-list-item {
+        margin: 0 -20px;
+      }
+      svg {
+        fill: currentColor;
+      }
+      a.bottom-left {
+        z-index: 1;
+        position: absolute;
+        line-height: 36px;
+        bottom: 9px;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-download-choose-dialog": ESPHomeDownloadChooseDialog;
+  }
+}

--- a/src/download-choose/index.ts
+++ b/src/download-choose/index.ts
@@ -6,12 +6,3 @@ export const openDownloadChooseDialog = (configuration: string) => {
   dialog.configuration = configuration;
   document.body.append(dialog);
 };
-
-export const attachDownloadChooseDialog = () => {
-  document.querySelectorAll("[data-action='upload']").forEach((btn) => {
-    btn.addEventListener("click", (ev) =>
-      openDownloadChooseDialog((ev.target as HTMLElement).dataset.filename!)
-    );
-    btn.addEventListener("mouseover", preload, { once: true });
-  });
-};

--- a/src/download-choose/index.ts
+++ b/src/download-choose/index.ts
@@ -1,0 +1,17 @@
+const preload = () => import("./download-choose-dialog");
+
+export const openDownloadChooseDialog = (configuration: string) => {
+  preload();
+  const dialog = document.createElement("esphome-download-choose-dialog");
+  dialog.configuration = configuration;
+  document.body.append(dialog);
+};
+
+export const attachDownloadChooseDialog = () => {
+  document.querySelectorAll("[data-action='upload']").forEach((btn) => {
+    btn.addEventListener("click", (ev) =>
+      openDownloadChooseDialog((ev.target as HTMLElement).dataset.filename!)
+    );
+    btn.addEventListener("mouseover", preload, { once: true });
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
 import "./devices/devices-list";
 import "./components/esphome-header-menu";
 import "./components/esphome-fab";
-import { attachInstallChooseDialog } from "./install-choose";
-
-attachInstallChooseDialog();

--- a/src/install-choose/index.ts
+++ b/src/install-choose/index.ts
@@ -6,12 +6,3 @@ export const openInstallChooseDialog = (configuration: string) => {
   dialog.configuration = configuration;
   document.body.append(dialog);
 };
-
-export const attachInstallChooseDialog = () => {
-  document.querySelectorAll("[data-action='upload']").forEach((btn) => {
-    btn.addEventListener("click", (ev) =>
-      openInstallChooseDialog((ev.target as HTMLElement).dataset.filename!)
-    );
-    btn.addEventListener("mouseover", preload, { once: true });
-  });
-};


### PR DESCRIPTION
- Move the download options from the install dialog to a new download dialog.
- Allow opening download dialog from configured device card overflow
- Add option to download YAML via download dialog
- When device connects via ethernet, name OTA update "Via the network" instead of Wirelessly (CC @digiblur)

![image](https://user-images.githubusercontent.com/1444314/191154169-b3ce34cd-b9a8-4738-a95b-862f0c2794d1.png)

![image](https://user-images.githubusercontent.com/1444314/191154198-be4ee146-c6e6-4279-a3e7-45021162ed21.png)
