### PR TITLE
Disable monaco source maps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,6 +53,7 @@ const config = {
     }),
     monaco({
       languages: ["yaml"],
+      sourcemap: false,
     }),
     nodeResolve(),
     commonjs(),


### PR DESCRIPTION
Disabling source maps changes build time in development from 8s to 3.4s on my machine (M1 Mac). We don't care about the source maps because if Monaco doesn't work, we can repro it locally with the source maps enabled.