### PR TITLE
Editor-tweaks

### DIFF
--- a/src/editor/esphome-editor.ts
+++ b/src/editor/esphome-editor.ts
@@ -53,7 +53,7 @@ export class ESPHomeEditor extends LitElement {
     this.editor = monaco.editor.create(this.container, {
       value: this.configuration,
       language: "yaml",
-      theme: "vs",
+      theme: "esphome",
       automaticLayout: true,
       // This is to have the popups above other stuff around the editor, otherwise they are hidden
       fixedOverflowWidgets: true,

--- a/src/editor/esphome-editor.ts
+++ b/src/editor/esphome-editor.ts
@@ -60,6 +60,7 @@ export class ESPHomeEditor extends LitElement {
       minimap: {
         enabled: false,
       },
+      tabSize: 2,
     });
 
     const filename = this.configuration;

--- a/src/editor/monaco-provider.ts
+++ b/src/editor/monaco-provider.ts
@@ -53,3 +53,13 @@ monaco.languages.registerDefinitionProvider("yaml", {
     };
   },
 });
+
+monaco.editor.defineTheme("esphome", {
+  base: "vs", // can also be vs-dark or hc-black
+  inherit: true, // can also be false to completely replace the builtin rules
+  rules: [{ token: "type", foreground: "000099", fontStyle: "" }],
+
+  colors: {
+    "editor.foreground": "#000000",
+  },
+});


### PR DESCRIPTION
* set darker blue for yaml keys to help differentiate from comments and also have more constrant (more or less the color used before)
* changed tab size to 2 (was default 4)