### PR TITLE
update monaco editor to 0.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@rollup/plugin-node-resolve": "^14.1.0",
         "@rollup/plugin-typescript": "^8.5.0",
         "fs-extra": "^10.1.0",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.34.0",
         "nunjucks": "^3.2.3",
         "postcss": "^8.4.16",
         "postcss-url": "^10.1.3",
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
+      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ==",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -5161,9 +5161,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
+      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ==",
       "dev": true
     },
     "nanoid": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@rollup/plugin-typescript": "^8.5.0",
     "fs-extra": "^10.1.0",
-    "monaco-editor": "^0.31.1",
+    "monaco-editor": "^0.34.0",
     "nunjucks": "^3.2.3",
     "postcss": "^8.4.16",
     "postcss-url": "^10.1.3",

--- a/src/editor/esphome-editor.ts
+++ b/src/editor/esphome-editor.ts
@@ -10,8 +10,6 @@ import { openInstallChooseDialog } from "../install-choose";
 import { getFile, writeFile } from "../api/files";
 import type { Snackbar } from "@material/mwc-snackbar";
 import { fireEvent } from "../util/fire-event";
-// @ts-ignore
-import editorStyles from "monaco-editor/min/vs/editor/editor.main.css";
 import { debounce } from "../util/debounce";
 import "./monaco-provider";
 
@@ -99,11 +97,7 @@ class ESPHomeEditor extends LitElement {
               @click=${this.handleInstall}
             ></mwc-button>`}
       </div>
-      <main>
-        <style>
-          ${editorStyles}
-        </style>
-      </main>
+      <main></main>
     `;
   }
 


### PR DESCRIPTION
Found out the issue was a combination of the 0.34 version and the editor being loaded on the shadow root, now that the editor is not loaded in shadow root we can upgrade to 0.34 also we don't need to inject the styles 

See also https://github.com/chengcyber/rollup-plugin-monaco-editor/issues/20#issuecomment-1260314306