### PR TITLE
Update style of status text

### DIFF
--- a/src/components/esphome-card.ts
+++ b/src/components/esphome-card.ts
@@ -61,9 +61,8 @@ export class ESPHomeCard extends LitElement {
     .status-bar::after {
       display: block;
       position: absolute;
-      right: 2px;
-      top: 3px;
-      font-weight: bold;
+      right: 6px;
+      top: 6px;
       font-size: 12px;
       content: attr(data-status);
     }

--- a/src/components/esphome-card.ts
+++ b/src/components/esphome-card.ts
@@ -62,7 +62,7 @@ export class ESPHomeCard extends LitElement {
       display: block;
       position: absolute;
       right: 6px;
-      top: 6px;
+      top: 4px;
       font-size: 12px;
       content: attr(data-status);
     }


### PR DESCRIPTION
I think this looks nicer and fits the overall design better.

Old:
![image](https://user-images.githubusercontent.com/5662298/193777713-916341e4-4737-4394-a62b-c9fcfe8dc2e5.png)
New:
![image](https://user-images.githubusercontent.com/5662298/193777747-d17bbb66-42c7-4df0-a45d-89d88ff582fa.png)

