### PR TITLE
Add list-view

### DIFF
--- a/src/components/esphome-card.ts
+++ b/src/components/esphome-card.ts
@@ -4,6 +4,8 @@ import { customElement, property } from "lit/decorators.js";
 @customElement("esphome-card")
 export class ESPHomeCard extends LitElement {
   @property() public status?: string;
+  @property({ attribute: "list", reflect: true, type: Boolean })
+  public list = false;
 
   @property({ attribute: "no-status-bar", reflect: true, type: Boolean })
   public noStatusBar = false;
@@ -30,10 +32,26 @@ export class ESPHomeCard extends LitElement {
       font-weight: normal;
     }
 
+    :host([list]) ::slotted(.card-header) {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      padding-top: 5px;
+      padding-bottom: 5px;
+    }
+
     :host ::slotted(.card-content:not(:first-child)),
     slot:not(:first-child)::slotted(.card-content) {
       padding-top: 0px;
       margin-top: -8px;
+    }
+
+    :host([list]) ::slotted(.card-content:not(:first-child)) {
+      margin-top: 0px;
+      padding: 5px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-end;
     }
 
     :host ::slotted(.card-content) {
@@ -67,6 +85,16 @@ export class ESPHomeCard extends LitElement {
       font-size: 12px;
       content: attr(data-status);
     }
+
+    :host([list]) .status-bar {
+      height: unset;
+      width: 4px;
+      position: unset;
+    }
+    :host([list]) .status-bar::after {
+      display: none;
+    }
+
     :host([no-status-bar]) .status-bar {
       height: 0px;
     }

--- a/src/components/esphome-header-menu.ts
+++ b/src/components/esphome-header-menu.ts
@@ -9,18 +9,26 @@ import { openEditDialog } from "../editor";
 import { SECRETS_FILE } from "../api/secrets";
 import { openUpdateAllDialog } from "../update-all";
 import { showConfirmationDialog } from "../dialogs";
+import ViewMode from "../devices/viewMode";
 
-const isWideListener = window.matchMedia("(min-width: 601px)");
+const isWideListener = window.matchMedia("(min-width: 655px)");
 
 @customElement("esphome-header-menu")
 export class ESPHomeHeaderMenu extends LitElement {
   @property({ type: String, attribute: "logout-url" }) logoutUrl?: string;
+  @property() toggleViewMode!: Function;
+  @property() viewMode: ViewMode = ViewMode.Module;
 
   @state() private _isWide = isWideListener.matches;
 
   protected render(): TemplateResult {
     if (this._isWide) {
       return html`
+        <mwc-button
+          icon="${this.viewMode === ViewMode.Module ? 'view_list' : 'view_modules'}"
+          label="${this.viewMode === ViewMode.Module ? 'List view' : 'Module view'}"
+          @click=${this.toggleViewMode}
+        ></mwc-button>
         <mwc-button
           icon="system_update"
           label="Update All"

--- a/src/components/esphome-header-menu.ts
+++ b/src/components/esphome-header-menu.ts
@@ -10,6 +10,7 @@ import { SECRETS_FILE } from "../api/secrets";
 import { openUpdateAllDialog } from "../update-all";
 import { showConfirmationDialog } from "../dialogs";
 import ViewMode from "../devices/viewMode";
+import { fireEvent } from "../util/fire-event";
 
 const isWideListener = window.matchMedia("(min-width: 655px)");
 
@@ -27,7 +28,7 @@ export class ESPHomeHeaderMenu extends LitElement {
         <mwc-button
           icon="${this.viewMode === ViewMode.Module ? 'view_list' : 'view_modules'}"
           label="${this.viewMode === ViewMode.Module ? 'List view' : 'Module view'}"
-          @click=${this.toggleViewMode}
+          @click=${() => fireEvent(this, "toggle-view-mode")}
         ></mwc-button>
         <mwc-button
           icon="system_update"

--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -46,6 +46,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
   @property() public device!: ConfiguredDevice;
   @property() public onlineStatus?: boolean;
   @property() public highlightOnAdd = false;
+  @property() public list = false;
   @state() private _highlight = false;
 
   public async highlight() {
@@ -89,6 +90,8 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
       : undefined;
     return html`
       <esphome-card
+        class=${this.list ? 'list' : ''}
+        .list=${this.list}
         .status=${status}
         .noStatusBar=${status === "ONLINE"}
         style=${styleMap({
@@ -214,6 +217,9 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
       .device-config-path {
         margin-bottom: 8px;
         font-size: 14px;
+      }
+      :host.listmode .device-config-path {
+        margin-bottom: 4px;
       }
       .inlinecode {
         box-sizing: border-box;

--- a/src/devices/devices-list.ts
+++ b/src/devices/devices-list.ts
@@ -1,6 +1,6 @@
 import { animate } from "@lit-labs/motion";
 import { LitElement, html, css } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { subscribeDevices, ListDevicesResult } from "../api/devices";
 import { openWizardDialog } from "../wizard";
@@ -8,11 +8,13 @@ import "@material/mwc-button";
 import { subscribeOnlineStatus } from "../api/online-status";
 import "./configured-device-card";
 import "./importable-device-card";
+import ViewMode from "./viewMode";
 
 @customElement("esphome-devices-list")
 class ESPHomeDevicesList extends LitElement {
   @state() private _devices?: ListDevicesResult;
   @state() private _onlineStatus?: Record<string, boolean>;
+  @property({ attribute: 'view-mode' }) viewMode: ViewMode = ViewMode.Module;
 
   private _devicesUnsub?: ReturnType<typeof subscribeDevices>;
   private _onlineStatusUnsub?: ReturnType<typeof subscribeOnlineStatus>;
@@ -45,7 +47,7 @@ class ESPHomeDevicesList extends LitElement {
     const importable = this._devices.importable;
 
     return html`
-      <div class="grid">
+      <div class="devices-list ${this.viewMode === ViewMode.Module ? 'grid' : 'list'}">
         ${importable.length
           ? html`
               ${repeat(
@@ -53,6 +55,7 @@ class ESPHomeDevicesList extends LitElement {
                 (device) => device.name,
                 (device) => html`
                   <esphome-importable-device-card
+                    class=${this.viewMode === ViewMode.List ? 'listmode' : ''}
                     ${animate({ id: device.name, skipInitial: true })}
                     .device=${device}
                     @adopted=${this._updateDevices}
@@ -66,6 +69,8 @@ class ESPHomeDevicesList extends LitElement {
           this._devices.configured,
           (device) => device.name,
           (device) => html`<esphome-configured-device-card
+            class=${this.viewMode === ViewMode.List ? 'listmode' : ''}
+            .list=${this.viewMode === ViewMode.List}
             ${animate({
               id: device.name,
               inId: device.name,
@@ -87,14 +92,16 @@ class ESPHomeDevicesList extends LitElement {
   }
 
   static styles = css`
+    .devices-list {
+      margin: 20px auto;
+      width: 90%;
+      max-width: 1920px;
+    }
     .grid {
       display: grid;
       grid-template-columns: 1fr;
       grid-template-columns: 1fr 1fr 1fr;
       grid-column-gap: 1.5rem;
-      margin: 20px auto;
-      width: 90%;
-      max-width: 1920px;
       justify-content: stretch;
     }
     @media only screen and (max-width: 1100px) {
@@ -116,6 +123,13 @@ class ESPHomeDevicesList extends LitElement {
     esphome-importable-device-card {
       margin: 0.5rem 0 1rem 0;
     }
+    esphome-configured-device-card.listmode,
+    esphome-importable-device-card.listmode {
+      display: block;
+      margin: 0;
+      border: 1px solid transparent;
+    }
+
     .welcome-container {
       text-align: center;
       margin-top: 40px;

--- a/src/devices/importable-device-card.ts
+++ b/src/devices/importable-device-card.ts
@@ -11,10 +11,14 @@ import { esphomeCardStyles } from "../styles";
 class ESPHomeImportableDeviceCard extends LitElement {
   @property() public device!: ImportableDevice;
   @property() public highlightOnAdd = false;
+  @property() public list = false;
 
   protected render() {
     return html`
-      <esphome-card status="DISCOVERED">
+      <esphome-card
+        class=${this.list ? 'list' : ''}
+        status="DISCOVERED"
+      >
         <div class="card-header">${this.device.name}</div>
         <div class="card-content flex">${this.device.project_name}</div>
 

--- a/src/devices/viewMode.ts
+++ b/src/devices/viewMode.ts
@@ -1,0 +1,6 @@
+enum ViewMode {
+  Module,
+  List
+}
+
+export default ViewMode

--- a/src/esphome-main.ts
+++ b/src/esphome-main.ts
@@ -47,7 +47,7 @@ class ESPHomeMainView extends LitElement {
           alt="ESPHome Logo"
         />
         <div class="flex"></div>
-        <esphome-header-menu .logoutUrl=${this.logoutUrl} .toggleViewMode=${this._toggleViewMode.bind(this)} .viewMode=${this.viewMode}></esphome-header-menu>
+        <esphome-header-menu .logoutUrl=${this.logoutUrl} @toggle-view-mode=${this._toggleViewMode} .viewMode=${this.viewMode}></esphome-header-menu>
       </div>
       <esphome-fab></esphome-fab>
       <footer class="page-footer grey darken-4">

--- a/src/esphome-main.ts
+++ b/src/esphome-main.ts
@@ -3,6 +3,9 @@ import "./components/esphome-header-menu";
 import "./components/esphome-fab";
 import { LitElement, html, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import ViewMode from "./devices/viewMode"
+
+const isWideListener = window.matchMedia("(min-width: 655px)");
 
 @customElement("esphome-main")
 class ESPHomeMainView extends LitElement {
@@ -13,6 +16,10 @@ class ESPHomeMainView extends LitElement {
   @property() logoutUrl?: string;
 
   @state() private editing?: string;
+
+  @state() private viewMode: ViewMode = Number(localStorage.getItem('esphome_viewmode')) || ViewMode.Module;
+
+  @state() private _isWide = isWideListener.matches;
 
   protected render() {
     if (this.editing) {
@@ -32,7 +39,7 @@ class ESPHomeMainView extends LitElement {
     }
     return html`
       <main>
-        <esphome-devices-list></esphome-devices-list>
+        <esphome-devices-list .viewMode=${this._isWide ? this.viewMode : ViewMode.Module}></esphome-devices-list>
       </main>
       <div class="esphome-header">
         <img
@@ -40,7 +47,7 @@ class ESPHomeMainView extends LitElement {
           alt="ESPHome Logo"
         />
         <div class="flex"></div>
-        <esphome-header-menu .logoutUrl=${this.logoutUrl}></esphome-header-menu>
+        <esphome-header-menu .logoutUrl=${this.logoutUrl} .toggleViewMode=${this._toggleViewMode.bind(this)} .viewMode=${this.viewMode}></esphome-header-menu>
       </div>
       <esphome-fab></esphome-fab>
       <footer class="page-footer grey darken-4">
@@ -74,6 +81,29 @@ class ESPHomeMainView extends LitElement {
   private _handleEditorClose() {
     this.editing = undefined;
   }
+
+  private _toggleViewMode() {
+    if (this.viewMode === ViewMode.Module) {
+      this.viewMode = ViewMode.List
+    } else {
+      this.viewMode = ViewMode.Module
+    }
+    localStorage.setItem('esphome_viewmode', this.viewMode.toString())
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    isWideListener.addEventListener("change", this._isWideUpdated);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    isWideListener.removeEventListener("change", this._isWideUpdated);
+  }
+
+  private _isWideUpdated = () => {
+    this._isWide = isWideListener.matches;
+  };
 }
 
 declare global {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -6,6 +6,9 @@ export const esphomeCardStyles = css`
     display: flex;
     flex-direction: column;
   }
+  esphome-card.list {
+    flex-direction: row;
+  }
   a {
     color: var(--mdc-theme-primary);
   }


### PR DESCRIPTION
Hello,

Add additional view option list.
Can be toggled via a button in the header menu.
View mode is saved in the localStorage of the browser.

This list-view should help to find devices faster in the list.

See preview:
![list-view-preview](https://user-images.githubusercontent.com/12148533/196151013-d8665024-21cf-4243-a9cd-52c68f10512c.gif)

This is my first work with lit. I am very open to feedback :smiley: 
