### PR TITLE
Reinstate close button on manual download

### DIFF
--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -280,6 +280,12 @@ class ESPHomeInstallChooseDialog extends LitElement {
             this._state = "pick_option";
           }}
         ></mwc-button>
+        <mwc-button
+          no-attention
+          slot="primaryAction"
+          dialogAction="close"
+          label="Close"
+        ></mwc-button>
       `;
     }
 


### PR DESCRIPTION
I removed the close button in #265 for the manual download page in the install choose dialog. This was a mistake and this reverts that change.