### PR TITLE
add missing scripts to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ Check out this repository, run `npm install --legacy-peer-deps` and then run
 
 ```
 script/develop
-````
+```
+
+if you are developing on Windows machine using VS Code, you must set bash as a default shell.
+You can do that by creating `.npmrc` file in the root of the project with the following content:
+
+```
+script-shell=C:\Program Files\git\bin\bash.exe
+```
 
 It will start the dev server and will automatically re-bundle updated JavaScript (except for the `static` folder).
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "author": "ESPHome maintainers",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "script/build"
+    "develop": "script/develop",
+    "build": "script/build",
+    "develop_web": "web.esphome.io/script/develop_web",
+    "build_web": "web.esphome.io/script/build_web"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^23.0.2",


### PR DESCRIPTION
This change adds missing scripts to package.json.
This allows running develop from VS Code menu:
![image](https://user-images.githubusercontent.com/1741838/201622539-d7e81771-de6b-4e2f-a948-248a74b11e34.png)

I've also added instructions for Windows users on how to set bash as a default shell per project to be able to call scripts.
Ref: https://stackoverflow.com/questions/74391024/vs-code-how-to-specify-npm-run-shell-per-project