### PR TITLE
Add ESP32-S3 Support

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -4,6 +4,7 @@ export type SupportedPlatforms =
   | "ESP8266"
   | "ESP32"
   | "ESP32S2"
+  | "ESP32S3"
   | "ESP32C3"
   | "RP2040";
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,7 @@
 import {
   CHIP_FAMILY_ESP32,
   CHIP_FAMILY_ESP32S2,
+  CHIP_FAMILY_ESP32S3,
   CHIP_FAMILY_ESP32C3,
   CHIP_FAMILY_ESP8266,
 } from "esp-web-flasher";
@@ -13,6 +14,7 @@ export const allowsWebSerial = window.isSecureContext;
 export const chipFamilyToPlatform = {
   [CHIP_FAMILY_ESP32]: "ESP32",
   [CHIP_FAMILY_ESP32S2]: "ESP32S2",
+  [CHIP_FAMILY_ESP32S3]: "ESP32S3",
   [CHIP_FAMILY_ESP32C3]: "ESP32C3",
   [CHIP_FAMILY_ESP8266]: "ESP8266",
 };

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -14,6 +14,7 @@ import {
   CHIP_FAMILY_ESP8266,
   CHIP_FAMILY_ESP32C3,
   CHIP_FAMILY_ESP32S2,
+  CHIP_FAMILY_ESP32S3,
 } from "esp-web-flasher";
 import { allowsWebSerial, supportsWebSerial } from "../const";
 import {
@@ -51,6 +52,7 @@ https://docs.google.com/drawings/d/1LAYImcreQdcUxtBt10K76FFypMGRTwu1tGBEERfAWkE/
 const BOARD_GENERIC_ESP32 = "esp32dev";
 const BOARD_GENERIC_ESP8266 = "esp01_1m";
 const BOARD_GENERIC_ESP32S2 = "esp32-s2-saola-1";
+const BOARD_GENERIC_ESP32S3 = "esp32-s3-devkitc-1";
 const BOARD_GENERIC_ESP32C3 = "esp32-c3-devkitm-1";
 const BOARD_RPI_PICO_W = "rpipicow";
 
@@ -62,6 +64,7 @@ export class ESPHomeWizardDialog extends LitElement {
     | typeof BOARD_GENERIC_ESP32
     | typeof BOARD_GENERIC_ESP8266
     | typeof BOARD_GENERIC_ESP32S2
+    | typeof BOARD_GENERIC_ESP32S3
     | typeof BOARD_GENERIC_ESP32C3
     | typeof BOARD_RPI_PICO_W
     | "CUSTOM" = BOARD_GENERIC_ESP32;
@@ -338,6 +341,15 @@ export class ESPHomeWizardDialog extends LitElement {
           .value=${BOARD_GENERIC_ESP32S2}
           @click=${this._handlePickBoardRadio}
           ?checked=${this._board === BOARD_GENERIC_ESP32S2}
+        ></mwc-radio>
+      </mwc-formfield>
+
+      <mwc-formfield label="ESP32-S3">
+        <mwc-radio
+          name="board"
+          .value=${BOARD_GENERIC_ESP32S3}
+          @click=${this._handlePickBoardRadio}
+          ?checked=${this._board === BOARD_GENERIC_ESP32S3}
         ></mwc-radio>
       </mwc-formfield>
 
@@ -635,6 +647,8 @@ export class ESPHomeWizardDialog extends LitElement {
         this._data.board = BOARD_GENERIC_ESP8266;
       } else if (esploader.chipFamily === CHIP_FAMILY_ESP32S2) {
         this._data.board = BOARD_GENERIC_ESP32S2;
+      } else if (esploader.chipFamily === CHIP_FAMILY_ESP32S3) {
+        this._data.board = BOARD_GENERIC_ESP32S3;
       } else if (esploader.chipFamily === CHIP_FAMILY_ESP32C3) {
         this._data.board = BOARD_GENERIC_ESP32C3;
       } else {


### PR DESCRIPTION
This PR seeks to add _core_ dashboard support for ESP32-S3 devices

The PR is based on #201 that added ESP32C3 and ESP32S2 support

To test run:

1. `ESPHOME_DASHBOARD_DEV=../dashboard esphome dashboard ./`
2. Click "+ New Device"
3. Observe that ESP32-S3 is now a selectable option from the primary menu

<img width="370" alt="image" src="https://user-images.githubusercontent.com/1016458/205785396-b9b5b3be-0d52-4859-b0ce-f79b2c548f0a.png">
