### PR TITLE
Always use factory image for flashing

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -31,8 +31,6 @@ export interface Configuration {
   loaded_integrations: string[];
 }
 
-export type Manifest = { path: string; offset: number }[];
-
 export const createConfiguration = (params: CreateConfigParams) =>
   fetchApiText("./wizard", {
     method: "post",
@@ -62,9 +60,6 @@ export const compileConfigurationMetadata = (
     undefined,
     abortController
   );
-
-export const getConfigurationManifest = (configuration: string) =>
-  fetchApiJson<Manifest>(`./manifest.json?configuration=${configuration}`);
 
 export const getDownloadUrl = (
   configuration: string,


### PR DESCRIPTION
This always uses the factory image for flashing instead of relying on a manifest.

This allows us to remove https://github.com/esphome/esphome/blob/dev/esphome/dashboard/dashboard.py#L498 from the backend.