### PR TITLE
Adjust icon colors in dropdown menu

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -228,6 +228,9 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
       .card-actions mwc-button.update-available {
         --mdc-theme-primary: var(--update-available-color);
       }
+      esphome-button-menu {
+        --mdc-theme-text-icon-on-background: rgba(0, 0, 0, 0.56);
+      }
       .tooltip-container {
         display: inline-block;
       }


### PR DESCRIPTION
Adjust the icon color in the dropdown menu to look less disabled.

Before:

![CleanShot 2022-12-09 at 12 18 34](https://user-images.githubusercontent.com/1444314/206757350-e0489f6d-34f2-47e9-9537-9d5f485da5a4.png)


After:


![CleanShot 2022-12-09 at 12 18 15](https://user-images.githubusercontent.com/1444314/206757304-3b64b603-1cb7-4373-a133-43770610b84a.png)
