### PR TITLE
Link Mac users to workaround for Pico

### DIFF
--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -238,7 +238,19 @@ class ESPHomeInstallChooseDialog extends LitElement {
             </li>
             <li>The Pico will show up as a USB drive named RPI-RP2</li>
             <li>${downloadButton}</li>
-            <li>Drag the downloaded file to the USB drive</li>
+            <li>
+              ${window.navigator.platform.startsWith("Mac")
+                ? html`
+                    <del>Drag the downloaded file to the USB drive</del><br />
+                    For users on a Mac, follow
+                    <a
+                      href="https://www.raspberrypi.com/news/the-ventura-problem/"
+                      target="_blank_"
+                      >these instructions</a
+                    >
+                  `
+                : "Drag the downloaded file to the USB drive"}
+            </li>
             <li>Your Pico will reboot and the installation is complete</li>
           </ol>
         `;


### PR DESCRIPTION
The hack Pico uses to fake being a USB flash drive to allow easy flashing [no longer works on a Mac](https://www.raspberrypi.com/news/the-ventura-problem/).

This PR will update the installation dialog to link that article, which includes a workaround to get it installed.

![CleanShot 2022-12-09 at 12 30 32](https://user-images.githubusercontent.com/1444314/206759295-391c4232-695d-4a3b-a8b7-f6d0d5c137d6.png)
