### PR TITLE
Allow server install for Pico running ESPHome

### DIFF
--- a/src/components/esphome-alert.ts
+++ b/src/components/esphome-alert.ts
@@ -1,0 +1,155 @@
+import {
+  mdiAlertCircleOutline,
+  mdiAlertOutline,
+  mdiCheckboxMarkedCircleOutline,
+  mdiInformationOutline,
+} from "@mdi/js";
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import "./esphome-svg-icon";
+
+const ALERT_ICONS = {
+  info: mdiInformationOutline,
+  warning: mdiAlertOutline,
+  error: mdiAlertCircleOutline,
+  success: mdiCheckboxMarkedCircleOutline,
+};
+
+@customElement("esphome-alert")
+class ESPHomeAlert extends LitElement {
+  @property() public title = "";
+
+  @property({ attribute: "alert-type" }) public alertType:
+    | "info"
+    | "warning"
+    | "error"
+    | "success" = "info";
+
+  @property({ type: Boolean }) public rtl = false;
+
+  public render() {
+    return html`
+      <div
+        class="issue-type ${classMap({
+          rtl: this.rtl,
+          [this.alertType]: true,
+        })}"
+        role="alert"
+      >
+        <div class="icon ${this.title ? "" : "no-title"}">
+          <slot name="icon">
+            <esphome-svg-icon
+              .path=${ALERT_ICONS[this.alertType]}
+            ></esphome-svg-icon>
+          </slot>
+        </div>
+        <div class="content">
+          <div class="main-content">
+            ${this.title ? html`<div class="title">${this.title}</div>` : ""}
+            <slot></slot>
+          </div>
+          <div class="action">
+            <slot name="action"> </slot>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    .issue-type {
+      position: relative;
+      padding: 8px;
+      display: flex;
+      padding-left: var(--esphome-alert-padding-left, 8px);
+    }
+    .issue-type.rtl {
+      flex-direction: row-reverse;
+    }
+    .issue-type::after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      opacity: 0.12;
+      pointer-events: none;
+      content: "";
+      border-radius: 4px;
+    }
+    .icon {
+      z-index: 1;
+    }
+    .icon.no-title {
+      align-self: center;
+    }
+    .issue-type.rtl > .content {
+      flex-direction: row-reverse;
+      text-align: right;
+    }
+    .content {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+    }
+    .action {
+      z-index: 1;
+      width: min-content;
+      --mdc-theme-primary: var(--primary-text-color);
+    }
+    .main-content {
+      overflow-wrap: anywhere;
+      word-break: break-word;
+      margin-left: 8px;
+      margin-right: 0;
+    }
+    .issue-type.rtl > .content > .main-content {
+      margin-left: 0;
+      margin-right: 8px;
+    }
+    .title {
+      margin-top: 2px;
+      font-weight: bold;
+    }
+    .action mwc-button,
+    .action ha-icon-button {
+      --mdc-theme-primary: var(--primary-text-color);
+      --mdc-icon-button-size: 36px;
+    }
+    .issue-type.info > .icon {
+      color: var(--alert-info-color);
+    }
+    .issue-type.info::after {
+      background-color: var(--alert-info-color);
+    }
+
+    .issue-type.warning > .icon {
+      color: var(--alert-warning-color);
+    }
+    .issue-type.warning::after {
+      background-color: var(--alert-warning-color);
+    }
+
+    .issue-type.error > .icon {
+      color: var(--alert-error-color);
+    }
+    .issue-type.error::after {
+      background-color: var(--alert-error-color);
+    }
+
+    .issue-type.success > .icon {
+      color: var(--alert-success-color);
+    }
+    .issue-type.success::after {
+      background-color: var(--alert-success-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-alert": ESPHomeAlert;
+  }
+}

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -16,6 +16,7 @@ import {
   getDownloadUrl,
 } from "../api/configuration";
 import { esphomeDialogStyles } from "../styles";
+import "../components/esphome-alert";
 
 const WARNING_ICON = "👀";
 const ESPHOME_WEB_URL = "https://web.esphome.io/?dashboard_install";
@@ -83,17 +84,12 @@ class ESPHomeInstallChooseDialog extends LitElement {
           ${metaChevronRight}
         </mwc-list-item>
 
-        <mwc-list-item
-          twoline
-          hasMeta
-          ?disabled=${this._isPico}
-          @click=${this._handleServerInstall}
-        >
+        <mwc-list-item twoline hasMeta @click=${this._handleServerInstall}>
           <span>Plug into the computer running ESPHome Dashboard</span>
           <span slot="secondary">
-            ${this._isPico
-              ? "Installing this from the server is not supported yet for this device"
-              : "For devices connected via USB to the server"}
+            ${`For devices connected via USB to the server${
+              this._isPico ? " and running ESPHome" : ""
+            }`}
           </span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -130,6 +126,14 @@ class ESPHomeInstallChooseDialog extends LitElement {
         this._ports === undefined
           ? this._renderProgress("Loading serial devices")
           : html`
+              ${this._isPico
+                ? html`
+                    <esphome-alert type="warning">
+                      Installation via the server requires the Pico to already
+                      run ESPHome.
+                    </esphome-alert>
+                  `
+                : ""}
               ${this._ports.length === 0
                 ? this._renderMessage(
                     WARNING_ICON,
@@ -527,6 +531,12 @@ class ESPHomeInstallChooseDialog extends LitElement {
         position: absolute;
         line-height: 36px;
         bottom: 9px;
+      }
+      esphome-alert {
+        color: black;
+        margin: 0 -24px;
+        display: block;
+        --esphome-alert-padding-left: 20px;
       }
     `,
   ];


### PR DESCRIPTION
Pico's can be installed server-side from ESPHome if the device is already running ESPHome.

We previously disabled the feature completely. This PR re-enables it and shows a note if a user is using a Pico.

![CleanShot 2022-12-09 at 13 00 30](https://user-images.githubusercontent.com/1444314/206764459-77409720-377e-4bca-99fb-83a09512ea42.png)
