### PR TITLE
Hide files with ".hide." in the filename from the UI

### DIFF
--- a/src/devices/devices-list.ts
+++ b/src/devices/devices-list.ts
@@ -67,18 +67,23 @@ class ESPHomeDevicesList extends LitElement {
         ${repeat(
           this._devices.configured,
           (device) => device.name,
-          (device) => html`<esphome-configured-device-card
-            ${animate({
-              id: device.name,
-              inId: device.name,
-              skipInitial: true,
-            })}
-            .device=${device}
-            @deleted=${this._updateDevices}
-            .onlineStatus=${(this._onlineStatus || {})[device.configuration]}
-            data-name=${device.name}
-            .highlightOnAdd=${this._highlightOnAdd}
-          ></esphome-configured-device-card>`
+          (device) =>
+            device.configuration.includes(".hide.")
+              ? html``
+              : html`<esphome-configured-device-card
+                  ${animate({
+                    id: device.name,
+                    inId: device.name,
+                    skipInitial: true,
+                  })}
+                  .device=${device}
+                  @deleted=${this._updateDevices}
+                  .onlineStatus=${(this._onlineStatus || {})[
+                    device.configuration
+                  ]}
+                  data-name=${device.name}
+                  .highlightOnAdd=${this._highlightOnAdd}
+                ></esphome-configured-device-card>`
         )}
       </div>
     `;


### PR DESCRIPTION
Currently there is no way to hide files/cards from the frontend UI. When developing or working on configuration files, you may not want them displayed in the UI. This is an example of a way this could be done via the filename. Another way could be adding information directly in the file themselves and gotten from the devices endpoint.

Running "Update All" will still try and update the hidden files. I am not sure where the change would need to be made skip files ending with ".hide." in the name.

New to Lit (and dev in general), so please let me know if this sort of PR is not acceptable.