### PR TITLE
Fix console not staying at bottom if new line spanned two lines

### DIFF
--- a/src/util/console-color.ts
+++ b/src/util/console-color.ts
@@ -178,13 +178,14 @@ export class ColoredConsole {
         }
       }
     }
+    const atBottom =
+      this.targetElement.scrollTop >
+      this.targetElement.scrollHeight - this.targetElement.offsetHeight - 50;
+
     addSpan(line.substring(i));
 
-    if (
-      this.targetElement.scrollTop + 56 >=
-      this.targetElement.scrollHeight - this.targetElement.offsetHeight
-    ) {
-      // at bottom
+    // Keep scroll at bottom
+    if (atBottom) {
       this.targetElement.scrollTop = this.targetElement.scrollHeight;
     }
   }


### PR DESCRIPTION
Test if we scrolled to the bottom of the console before adding a new line. This fixes the bug where a new line that would wrap to 2+ lines would break the auto-scroll at the bottom.