### PR TITLE
Bump loader-utils to fix audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,9 +2210,10 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "3.2.0",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -4690,8 +4691,7 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-select": {
       "version": "4.3.0",
@@ -4772,8 +4772,7 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -4970,8 +4969,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -5243,7 +5241,9 @@
       }
     },
     "loader-utils": {
-      "version": "3.2.0",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -5436,23 +5436,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-load-config": {
       "version": "3.1.4",
@@ -5534,8 +5530,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -5562,8 +5557,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",


### PR DESCRIPTION
npm audit was raising this warning. Fixed it.