### PR TITLE
Fix "Show API Key" dialog shows "Loading..." forever if no encryption key in config

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -81,7 +81,7 @@ export const getJsonConfig = async (
 
 export const getConfigurationApiKey = async (
   configuration: string
-): Promise<string | undefined> => {
+): Promise<string | null> => {
   const config = await getJsonConfig(configuration);
-  return config?.api?.encryption?.key;
+  return config?.api?.encryption?.key || null;
 };

--- a/src/show-api-key/show-api-key-dialog.ts
+++ b/src/show-api-key/show-api-key-dialog.ts
@@ -26,8 +26,8 @@ class ESPHomeShowApiKeyDialogDialog extends LitElement {
         ${this._apiKey === undefined
           ? "Loading…"
           : this._apiKey === null
-          ? html`Unable to automatically extract API key. Open the configuration
-              and look for <code>api:</code>.`
+          ? html`Unable to automatically extract API key. It may not be set.
+              Open the configuration and look for <code>api:</code>.`
           : html`
               <div class="key" @click=${this._copyApiKey}>
                 <code>${this._apiKey}</code>

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -91,7 +91,7 @@ export class ESPHomeWizardDialog extends LitElement {
   @state() private _error?: string;
 
   private _installed = false;
-  private _apiKey?: string;
+  private _apiKey?: string | null;
 
   @query("mwc-textfield[name=name]") private _inputName!: TextField;
   @query("mwc-textfield[name=ssid]") private _inputSSID!: TextField;


### PR DESCRIPTION
I think this is a minimally correct set of changes to fix #400. When choosing the "Show API Key" menu item, this will show "Loading..." until a response comes back, and then it either shows the key or an error message, based on whether we get a string or `null`.

The wizard-dialog doesn't differentiate between `undefined` and `null`, instead using truthiness of the `_apiKey` to show / hide a section with the key. In my testing, I wasn't able to find a path that'd trigger the "no API Key" flow in the wizard, but I don't think I've broken anything.

I don't have much experience with this web stack, so I hope I've done an okay job w/the changes.