### PR TITLE
Hide the header if browser unsupported

### DIFF
--- a/web.esphome.io/src/components/ew-header-menu.ts
+++ b/web.esphome.io/src/components/ew-header-menu.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement, TemplateResult } from "lit";
 import { property, state, customElement } from "lit/decorators.js";
 import "@material/mwc-button";
+import { supportsWebSerial } from "../../../src/const";
 
 const isWideListener = window.matchMedia("(min-width: 601px)");
 
@@ -13,6 +14,9 @@ export class EWHeaderMenu extends LitElement {
   @state() private _pico = false;
 
   protected render(): TemplateResult {
+    if (!supportsWebSerial) {
+      return html``;
+    }
     return html`
       <a href=${this._pico ? "/" : "/?pico"}>
         <mwc-button


### PR DESCRIPTION
If the browser is unsupported, do not show the switcher for ESP/Pico in the header.