### PR TITLE
Fix icon alignment with text on buttons

### DIFF
--- a/src/components/esphome-header-menu.ts
+++ b/src/components/esphome-header-menu.ts
@@ -111,6 +111,7 @@ export class ESPHomeHeaderMenu extends LitElement {
     mwc-button {
       --mdc-theme-primary: black;
       margin-left: 16px;
+      line-height: 1em;
     }
     a {
       text-decoration: none;

--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -140,57 +140,65 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
             @action=${this._handleOverflowAction}
           >
             <mwc-icon-button slot="trigger" icon="more_vert"></mwc-icon-button>
-            <mwc-list-item graphic="icon"
-              >Validate<esphome-svg-icon
+            <mwc-list-item graphic="icon">
+              Validate
+              <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiSpellcheck}
-              ></esphome-svg-icon
-            ></mwc-list-item>
-            <mwc-list-item graphic="icon"
-              >Install<esphome-svg-icon
+              ></esphome-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Install
+              <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiUploadNetwork}
-              ></esphome-svg-icon
-            ></mwc-list-item>
-            <mwc-list-item graphic="icon"
-              >Show API Key<esphome-svg-icon
+              ></esphome-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Show API Key
+              <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiKey}
-              ></esphome-svg-icon
-            ></mwc-list-item>
-            <mwc-list-item graphic="icon"
-              >Download YAML<esphome-svg-icon
+              ></esphome-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Download YAML
+              <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiCodeBraces}
-              ></esphome-svg-icon
-            ></mwc-list-item>
-            <mwc-list-item graphic="icon"
-              >Rename<esphome-svg-icon
+              ></esphome-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Rename
+              <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiRenameBox}
-              ></esphome-svg-icon
-            ></mwc-list-item>
-            <mwc-list-item graphic="icon"
-              >Clean Build Files<esphome-svg-icon
+              ></esphome-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Clean Build Files
+              <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiBroom}
-              ></esphome-svg-icon
-            ></mwc-list-item>
+              ></esphome-svg-icon>
+            </mwc-list-item>
             <li divider role="separator"></li>
-            <mwc-list-item class="warning" graphic="icon"
-              >Delete<esphome-svg-icon
+            <mwc-list-item class="warning" graphic="icon">
+              Delete
+              <esphome-svg-icon
                 class="warning"
                 slot="graphic"
                 .path=${mdiDelete}
-              ></esphome-svg-icon
-            ></mwc-list-item>
+              ></esphome-svg-icon>
+            </mwc-list-item>
             ${"mqtt" in this.device.loaded_integrations
-              ? html`<mwc-list-item graphic="icon"
-                  >Clean MQTT<esphome-svg-icon
+              ? html`<mwc-list-item graphic="icon">
+                  Clean MQTT
+                  <esphome-svg-icon
                     slot="graphic"
                     .path=${mdiBroom}
-                  ></esphome-svg-icon
-                ></mwc-list-item>`
+                  ></esphome-svg-icon>
+                </mwc-list-item>`
               : ""}
           </esphome-button-menu>
         </div>

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -12,6 +12,9 @@ export const esphomeCardStyles = css`
   .flex {
     flex: 1;
   }
+  mwc-button {
+    line-height: 1em;
+  }
   .card-actions {
     display: flex;
     padding: 4px;

--- a/web.esphome.io/src/components/ew-header-menu.ts
+++ b/web.esphome.io/src/components/ew-header-menu.ts
@@ -56,6 +56,7 @@ export class EWHeaderMenu extends LitElement {
     mwc-button {
       --mdc-theme-primary: black;
       margin-left: 16px;
+      line-height: 1em;
     }
     mwc-button img {
       height: 32px;

--- a/web.esphome.io/src/dashboard/arrow.ts
+++ b/web.esphome.io/src/dashboard/arrow.ts
@@ -9,3 +9,11 @@ export const ARROW = html`
     </svg>
   </div>
 `;
+
+export const ARROW_RIGHT = html`
+  <svg width="48" height="48" viewBox="0 0 24 24">
+    <path
+      d="M21.5 9.5L20.09 10.92L17 7.83V13.5C17 17.09 14.09 20 10.5 20H4V18H10.5C13 18 15 16 15 13.5V7.83L11.91 10.91L10.5 9.5L16 4L21.5 9.5Z"
+    />
+  </svg>
+`;

--- a/web.esphome.io/src/dashboard/esp-connect-card.ts
+++ b/web.esphome.io/src/dashboard/esp-connect-card.ts
@@ -26,7 +26,11 @@ class EWESPConnectCard extends LitElement {
         </div>
 
         <div class="card-actions">
-          <mwc-button label="Connect" @click=${this.connect}></mwc-button>
+          <mwc-button
+            icon="link"
+            label="Connect"
+            @click=${this.connect}
+          ></mwc-button>
         </div>
       </esphome-card>
     `;

--- a/web.esphome.io/src/dashboard/esp-device-card.ts
+++ b/web.esphome.io/src/dashboard/esp-device-card.ts
@@ -4,6 +4,7 @@ import "@material/mwc-icon-button";
 import type { ActionDetail } from "@material/mwc-list";
 import { LitElement, html, css, PropertyValues } from "lit";
 import { customElement } from "lit/decorators.js";
+import "../../../src/components/esphome-svg-icon";
 import "../../../src/components/esphome-card";
 import "../../../src/components/esphome-button-menu";
 import { fireEvent } from "../../../src/util/fire-event";
@@ -20,6 +21,7 @@ import {
   openInstallAdoptableDialog,
 } from "../install-adoptable";
 import { esphomeCardStyles } from "../../../src/styles";
+import { mdiLinkOff, mdiWifiCog } from "@mdi/js";
 
 @customElement("ew-esp-device-card")
 class EWESPDeviceCard extends LitElement {
@@ -32,20 +34,34 @@ class EWESPDeviceCard extends LitElement {
         <div class="card-content flex"></div>
 
         <div class="card-actions">
-          <mwc-button label="Logs" @click=${this.showLogs}></mwc-button>
-          <mwc-button label="Install" @click=${this.showInstall}></mwc-button>
           <mwc-button
-            label="Prepare for adoption"
+            class="first-use"
+            icon="system_update"
+            label="Prepare for first use"
             @click=${this.showAdoptable}
           ></mwc-button>
+          <mwc-button label="Install" @click=${this.showInstall}></mwc-button>
+          <mwc-button label="Logs" @click=${this.showLogs}></mwc-button>
           <div class="flex"></div>
           <esphome-button-menu
             corner="BOTTOM_RIGHT"
             @action=${this._handleOverflowAction}
           >
             <mwc-icon-button slot="trigger" icon="more_vert"></mwc-icon-button>
-            <mwc-list-item>Configure Wi-Fi</mwc-list-item>
-            <mwc-list-item>Disconnect</mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Configure Wi-Fi
+              <esphome-svg-icon
+                slot="graphic"
+                .path=${mdiWifiCog}
+              ></esphome-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Disconnect
+              <esphome-svg-icon
+                slot="graphic"
+                .path=${mdiLinkOff}
+              ></esphome-svg-icon>
+            </mwc-list-item>
           </esphome-button-menu>
         </div>
       </esphome-card>
@@ -93,6 +109,12 @@ class EWESPDeviceCard extends LitElement {
     css`
       esphome-card {
         --status-color: rgba(0, 0, 0, 0.5);
+      }
+      esphome-button-menu {
+        --mdc-theme-text-icon-on-background: rgba(0, 0, 0, 0.56);
+      }
+      mwc-button.first-use {
+        --mdc-theme-primary: var(--update-available-color);
       }
     `,
   ];

--- a/web.esphome.io/src/dashboard/ew-dashboard.ts
+++ b/web.esphome.io/src/dashboard/ew-dashboard.ts
@@ -5,7 +5,7 @@ import "./unsupported-card";
 import "./esp-connect-card";
 import "./pico-connect-card";
 import { supportsWebSerial } from "../../../src/const";
-import { ARROW } from "./arrow";
+import { ARROW, ARROW_RIGHT } from "./arrow";
 
 @customElement("ew-dashboard")
 class EWDashboard extends LitElement {
@@ -14,31 +14,28 @@ class EWDashboard extends LitElement {
   protected render() {
     return html`
       <div class="container">
-        ${
-          !supportsWebSerial
-            ? html`<ew-unsupported-card></ew-unsupported-card>`
-            : this.pico
-            ? html`<ew-pico-connect-card></ew-pico-connect-card>`
-            : html`<ew-esp-connect-card></ew-esp-connect-card>`
-        }
+        ${!supportsWebSerial
+          ? html`<ew-unsupported-card></ew-unsupported-card>`
+          : this.pico
+          ? html`<ew-pico-connect-card></ew-pico-connect-card>`
+          : html`<ew-esp-connect-card></ew-esp-connect-card>`}
 
         <div class="intro">
           ${ARROW}
           <div class="text">
             <p><b>Welcome to ESPHome Web!</b></p>
             <p>
-              ESPHome Web allows you to prepare your ${
-                this.pico
-                  ? html`
-                      <a
-                        href="https://www.raspberrypi.com/products/raspberry-pi-pico/"
-                        >Raspberry&nbsp;Pi Pico&nbsp;W</a
-                      >
-                    `
-                  : "device"
-              } for first use${
-      this.pico ? "" : ", install new versions"
-    } and check the device logs directly from your browser.
+              ESPHome Web allows you to prepare your
+              ${this.pico
+                ? html`
+                    <a
+                      href="https://www.raspberrypi.com/products/raspberry-pi-pico/"
+                      >Raspberry&nbsp;Pi Pico&nbsp;W</a
+                    >
+                  `
+                : "device"}
+              for first use${this.pico ? "" : ", install new versions"} and
+              check the device logs directly from your browser.
             </p>
             <p>
               ESPHome Web runs 100% in your browser. No data will leave your
@@ -57,10 +54,12 @@ class EWDashboard extends LitElement {
           </div>
         </div>
 
-        <div class="promote promote-install">
-          ${ARROW}
+        <div class="promote promote-install right-arrow">
           <div class="text">
-            <p><b>Install downloaded project</b></p>
+            <p>
+              <b>Install downloaded project</b>
+              ${ARROW_RIGHT}
+            </p>
             <p>
               If you have a downloaded version of your project, you can install
               it on your device here.
@@ -68,27 +67,28 @@ class EWDashboard extends LitElement {
           </div>
         </div>
 
-        <div class="promote promote-logs">
-          ${ARROW}
+        <div class="promote promote-logs right-arrow">
           <div class="text">
-            <p><b>Check logs</b></p>
             <p>
-              Click here to check the device logs. If you don't see logs
-              output, press the reset device button.
+              <b>Check logs</b>
+              ${ARROW_RIGHT}
+            </p>
+            <p>
+              Click here to check the device logs. If you don't see logs output,
+              press the reset device button.
             </p>
           </div>
         </div>
 
         <div class="promote promote-adopt">
-          </svg>
+          ${ARROW}
           <div class="text">
-            <p><b>Make Adoptable</b>
-            <svg width="48" height="48" viewBox="0 0 24 24"><path d="M21.5 9.5L20.09 10.92L17 7.83V13.5C17 17.09 14.09 20 10.5 20H4V18H10.5C13 18 15 16 15 13.5V7.83L11.91 10.91L10.5 9.5L16 4L21.5 9.5Z" /></svg>
-
-          </p>
             <p>
-              This action will prepare your device to be adopted by your ESPHome
-              dashboard. Once adopted, a device can be configured and updated
+              <b>Prepare for first use</b>
+            </p>
+            <p>
+              Install ESPHome on your device to add it to your ESPHome
+              dashboard. Once added, a device can be configured and updated
               wirelessly.
             </p>
           </div>
@@ -141,13 +141,7 @@ class EWDashboard extends LitElement {
     ew-esp-connect-card[connected] + .intro {
       display: none;
     }
-    .promote-install {
-      padding-left: 83px;
-    }
-    .promote-logs {
-      padding-left: 20px;
-    }
-    ew-esp-connect-card ~ .promote,
+    ew-esp2-connect-card ~ .promote,
     ew-pico-connect-card ~ .promote,
     ew-unsupported-card ~ .promote {
       display: none;
@@ -168,17 +162,28 @@ class EWDashboard extends LitElement {
       padding-right: 8px;
       flex: 1;
     }
+    .promote-adopt {
+      margin-left: 180px;
+    }
+    .promote-install {
+      padding-left: 5px;
+    }
+    .promote-logs {
+      padding-left: 80px;
+    }
     .arrow svg {
       position: relative;
       top: -13px;
     }
-    .promote-adopt p:first-child {
+    .right-arrow p:first-child {
       margin-top: 0;
     }
-    .promote-adopt svg {
+    .right-arrow svg {
       position: relative;
-      left: 32px;
       bottom: -5px;
+    }
+    .promote-logs.right-arrow svg {
+      left: 108px;
     }
   `;
 }

--- a/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
+++ b/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
@@ -14,7 +14,7 @@ class ESPHomeInstallAdoptableDialog extends LitElement {
     return html`
       <mwc-dialog
         open
-        heading="Prepare your device for adoption"
+        heading="Prepare your device for first use"
         scrimClickAction
         @closed=${this._handleClose}
       >
@@ -30,7 +30,7 @@ class ESPHomeInstallAdoptableDialog extends LitElement {
 
         <mwc-button
           slot="primaryAction"
-          label="Make Adoptable"
+          label="Install"
           @click=${this._handleInstall}
         ></mwc-button>
         <mwc-button


### PR DESCRIPTION
The icon alignment on buttons was off due to a global `line-height` CSS rule. This corrects it for the header and cards.

Before:

![CleanShot 2023-01-14 at 13 32 14](https://user-images.githubusercontent.com/1444314/212490172-c4367830-37f5-4270-99d9-ccced67f5ae4.png)

After:

![CleanShot 2023-01-14 at 13 32 27](https://user-images.githubusercontent.com/1444314/212490182-93d5b477-e0ca-49b8-876a-c251826bb78f.png)
