### PR TITLE
Add support for friendly name

### DIFF
--- a/src/adopt/adopt-dialog.ts
+++ b/src/adopt/adopt-dialog.ts
@@ -132,8 +132,8 @@ class ESPHomeAdoptDialog extends LitElement {
       heading = "Installation skipped";
       content = html`
         <div>
-          You will be able to rename the device and install the configuration at
-          a later point from the three-dot menu on the device card.
+          You will be able to install the configuration at a later point from
+          the three-dot menu on the device card.
         </div>
         <mwc-button
           slot="primaryAction"

--- a/src/adopt/adopt-dialog.ts
+++ b/src/adopt/adopt-dialog.ts
@@ -20,6 +20,7 @@ class ESPHomeAdoptDialog extends LitElement {
   @state() private _busy = false;
   @state() private _error?: string;
 
+  private _nameOverride?: string;
   private _configFilename!: string;
 
   @query("mwc-textfield[name=ssid]") private _inputSSID!: TextField;
@@ -109,9 +110,8 @@ class ESPHomeAdoptDialog extends LitElement {
       heading = "Configuration created";
       content = html`
         <div>
-          To finish adoption of
-          ${this.device.friendly_name || this.device.name}, the new
-          configuration needs to be installed on the device.
+          To finish adoption of ${this._nameOverride || this.device.name}, the
+          new configuration needs to be installed on the device.
         </div>
 
         <mwc-button
@@ -234,6 +234,7 @@ class ESPHomeAdoptDialog extends LitElement {
       let data = this.device;
       if (hasFriendlyName) {
         data = { ...data, friendly_name: this._inputName.value };
+        this._nameOverride = data.friendly_name;
       }
       const response = await importDevice(data);
       this._configFilename = response.configuration;

--- a/src/adopt/adopt-dialog.ts
+++ b/src/adopt/adopt-dialog.ts
@@ -34,9 +34,9 @@ class ESPHomeAdoptDialog extends LitElement {
       heading = "Adopt device";
       content = html`
         <div>
-          Adopting ${this.device.name} will create an ESPHome configuration for
-          this device. This allows you to install updates and customize the
-          original firmware.
+          Adopting ${this.device.friendly_name || this.device.name} will create
+          an ESPHome configuration for this device. This allows you to install
+          updates and customize the original firmware.
         </div>
 
         ${this._error ? html`<div class="error">${this._error}</div>` : ""}
@@ -213,7 +213,7 @@ class ESPHomeAdoptDialog extends LitElement {
       return;
     }
 
-    if (storeWifiSecrets) {
+    if (shouldStoreWifiSecrets) {
       this._busy = true;
       try {
         await storeWifiSecrets(
@@ -221,6 +221,7 @@ class ESPHomeAdoptDialog extends LitElement {
           this._inputPassword.value
         );
       } catch (err) {
+        console.error(err);
         this._busy = false;
         this._error = "Failed to store Wi-Fi credentials";
         return;

--- a/src/adopt/adopt-dialog.ts
+++ b/src/adopt/adopt-dialog.ts
@@ -109,8 +109,9 @@ class ESPHomeAdoptDialog extends LitElement {
       heading = "Configuration created";
       content = html`
         <div>
-          To finish adoption of ${this.device.name}, the new configuration needs
-          to be installed on the device.
+          To finish adoption of
+          ${this.device.friendly_name || this.device.name}, the new
+          configuration needs to be installed on the device.
         </div>
 
         <mwc-button

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -25,7 +25,7 @@ export interface Configuration {
 }
 
 export const createConfiguration = (params: CreateConfigParams) =>
-  fetchApiText("./wizard", {
+  fetchApiJson<{ configuration: string }>("./wizard", {
     method: "post",
     body: JSON.stringify(params),
   });

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -1,9 +1,10 @@
-import { fetchApiJson, fetchApiText } from ".";
+import { fetchApiJson } from ".";
 import { SupportedPlatforms } from "../const";
 import { createPollingCollection } from "../util/polling-collection";
 
 export interface ConfiguredDevice {
   name: string;
+  friendly_name: string;
   configuration: string;
   loaded_integrations: string[];
   deployed_version: string;
@@ -17,6 +18,7 @@ export interface ConfiguredDevice {
 
 export interface ImportableDevice {
   name: string;
+  friendly_name: string;
   package_import_url: string;
   project_name: string;
   project_version: string;
@@ -31,7 +33,7 @@ export interface ListDevicesResult {
 export const getDevices = () => fetchApiJson<ListDevicesResult>("./devices");
 
 export const importDevice = (params: ImportableDevice) =>
-  fetchApiText("./import", {
+  fetchApiJson<{ configuration: string }>("./import", {
     method: "post",
     body: JSON.stringify(params),
   });

--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -60,8 +60,9 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
     const content: TemplateResult[] = [];
 
     if (
-      this.device.configuration !== `${this.device.name}.yaml` &&
-      this.device.configuration !== `${this.device.name}.yml`
+      this.device.friendly_name ||
+      (this.device.configuration !== `${this.device.name}.yaml` &&
+        this.device.configuration !== `${this.device.name}.yml`)
     ) {
       content.push(html`
         <div class="device-config-path tooltip-container">
@@ -95,7 +96,9 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
           "--status-color": status === undefined ? "" : STATUS_COLORS[status],
         })}
       >
-        <div class="card-header">${this.device.name}</div>
+        <div class="card-header">
+          ${this.device.friendly_name || this.device.name}
+        </div>
 
         ${content.length
           ? html`<div class="card-content flex">${content}</div>`
@@ -169,7 +172,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
               ></esphome-svg-icon>
             </mwc-list-item>
             <mwc-list-item graphic="icon">
-              Rename
+              Rename hostname
               <esphome-svg-icon
                 slot="graphic"
                 .path=${mdiRenameBox}

--- a/src/devices/importable-device-card.ts
+++ b/src/devices/importable-device-card.ts
@@ -15,8 +15,19 @@ class ESPHomeImportableDeviceCard extends LitElement {
   protected render() {
     return html`
       <esphome-card status="DISCOVERED">
-        <div class="card-header">${this.device.name}</div>
-        <div class="card-content flex">${this.device.project_name}</div>
+        <div class="card-header">
+          ${this.device.friendly_name || this.device.name}
+        </div>
+        <div class="card-content flex">
+          ${this.device.friendly_name
+            ? html`
+                <div class="device-config-path tooltip-container">
+                  <code class="inlinecode">${this.device.name}</code>
+                </div>
+              `
+            : ""}
+          ${this.device.project_name}
+        </div>
 
         <div class="card-actions">
           <mwc-button
@@ -44,6 +55,16 @@ class ESPHomeImportableDeviceCard extends LitElement {
     css`
       esphome-card {
         --status-color: #4caf50;
+      }
+      .inlinecode {
+        box-sizing: border-box;
+        padding: 0.2em 0.4em;
+        margin: 0;
+        font-size: 85%;
+        background-color: rgba(27, 31, 35, 0.05);
+        border-radius: 3px;
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+          Courier, monospace;
       }
       .card-actions mwc-button {
         --mdc-theme-primary: #4caf50;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -53,6 +53,7 @@ export const esphomeDialogStyles = css`
     margin-top: 0;
   }
 
+  mwc-textfield + div,
   div + div {
     margin-top: 16px;
   }


### PR DESCRIPTION
First pass for adding support for friendly name (https://github.com/esphome/esphome/pull/4296) to the frontend:

- Wizard now asks for friendly name, not hostname
- Adoption will now ask for new friendly name if to-be imported project has a friendly name set
- Adoption no longer offers to rename hostname
- Device dashboard: adoption card now shows the hostname if header is friendly name
- Device dashboard: configured card now always shows the configuration path if header is friendly name

![CleanShot 2023-01-15 at 22 21 19](https://user-images.githubusercontent.com/1444314/212591770-db8d70c8-f06b-4506-8f28-b4b117cd9bba.png)

I am not too happy with how the configuration path looks on a configured device card. Previously that was not a problem as it was hidden when it was the same as the name (99% of the cases). Will revisit in a future PR.