### PR TITLE
First pass at a dark theme

### DIFF
--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -31,15 +31,15 @@
     --primary-bg-color: #212121;
     --primary-footer-bg-color: #080808;
 
-    --mdc-theme-surface: #C0C0C0;
+    --mdc-theme-surface: #c0c0c0;
 
-    --esphome-background-header: #C0C0C0;
+    --esphome-background-header: #c0c0c0;
 
     --card-background-color: #888888;
-    --card-status-color: #FFFFFF;
+    --card-status-color: #ffffff;
   }
   html {
-    color: #FFFFFF;
+    color: #ffffff;
   }
 }
 

--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -28,7 +28,7 @@
 /* dark theme */
 @media (prefers-color-scheme: dark) {
   :root {
-    --primary-bg-color: #111;
+    --primary-bg-color: #111111;
     --primary-footer-bg-color: #101e24;
 
     --esphome-background-header: #c0c0c0;

--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -22,24 +22,27 @@
   --esphome-background-header: #e0e0e0;
 
   --card-background-color: #ffffff;
-  --card-status-color: rgba(0, 0, 0, 0.5);
+  --card-text-color: rgba(0, 0, 0, 0.88);
 }
 
 /* dark theme */
 @media (prefers-color-scheme: dark) {
   :root {
-    --primary-bg-color: #212121;
-    --primary-footer-bg-color: #080808;
+    --primary-text-color: #e1e1e1;
+
+    --primary-bg-color: #111;
+    --primary-footer-bg-color: #101e24;
 
     --mdc-theme-surface: #c0c0c0;
 
     --esphome-background-header: #c0c0c0;
 
-    --card-background-color: #888888;
-    --card-status-color: #ffffff;
+    --card-background-color: #1c1c1c;
+    --card-text-color: #e1e1e1;
+
   }
   html {
-    color: #ffffff;
+    color: #e1e1e1;
   }
 }
 

--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -20,7 +20,29 @@
   --mdc-dialog-z-index: 998;
 
   --esphome-background-header: #e0e0e0;
+
+  --card-background-color: #ffffff;
+  --card-status-color: rgba(0, 0, 0, 0.5);
 }
+
+/* dark theme */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-bg-color: #212121;
+    --primary-footer-bg-color: #080808;
+
+    --mdc-theme-surface: #C0C0C0;
+
+    --esphome-background-header: #C0C0C0;
+
+    --card-background-color: #888888;
+    --card-status-color: #FFFFFF;
+  }
+  html {
+    color: #FFFFFF;
+  }
+}
+
 
 html {
   font-size: 15px;

--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -28,18 +28,13 @@
 /* dark theme */
 @media (prefers-color-scheme: dark) {
   :root {
-    --primary-text-color: #e1e1e1;
-
     --primary-bg-color: #111;
     --primary-footer-bg-color: #101e24;
-
-    --mdc-theme-surface: #c0c0c0;
 
     --esphome-background-header: #c0c0c0;
 
     --card-background-color: #1c1c1c;
     --card-text-color: #e1e1e1;
-
   }
   html {
     color: #e1e1e1;

--- a/web.esphome.io/src/dashboard/arrow.ts
+++ b/web.esphome.io/src/dashboard/arrow.ts
@@ -2,7 +2,7 @@ import { html } from "lit";
 
 export const ARROW = html`
   <div class="arrow">
-    <svg width="48" height="48" viewBox="0 0 24 24">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
       <path
         d="M20 18V20H13.5C9.91 20 7 17.09 7 13.5V7.83L3.91 10.92L2.5 9.5L8 4L13.5 9.5L12.09 10.91L9 7.83V13.5C9 16 11 18 13.5 18H20Z"
       />
@@ -11,7 +11,7 @@ export const ARROW = html`
 `;
 
 export const ARROW_RIGHT = html`
-  <svg width="48" height="48" viewBox="0 0 24 24">
+  <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
     <path
       d="M21.5 9.5L20.09 10.92L17 7.83V13.5C17 17.09 14.09 20 10.5 20H4V18H10.5C13 18 15 16 15 13.5V7.83L11.91 10.91L10.5 9.5L16 4L21.5 9.5Z"
     />

--- a/web.esphome.io/src/dashboard/esp-device-card.ts
+++ b/web.esphome.io/src/dashboard/esp-device-card.ts
@@ -108,7 +108,7 @@ class EWESPDeviceCard extends LitElement {
     esphomeCardStyles,
     css`
       esphome-card {
-        --status-color: rgba(0, 0, 0, 0.5);
+        --status-color: var(--card-status-color);
       }
       esphome-button-menu {
         --mdc-theme-text-icon-on-background: rgba(0, 0, 0, 0.56);

--- a/web.esphome.io/src/dashboard/esp-device-card.ts
+++ b/web.esphome.io/src/dashboard/esp-device-card.ts
@@ -108,12 +108,16 @@ class EWESPDeviceCard extends LitElement {
     esphomeCardStyles,
     css`
       esphome-card {
-        --status-color: var(--card-status-color);
+        --status-color: var(--card-text-color);
+      }
+      .card-actions mwc-button {
+        --mdc-theme-primary: var(--card-text-color);
       }
       esphome-button-menu {
+        color: var(--card-text-color);
         --mdc-theme-text-icon-on-background: rgba(0, 0, 0, 0.56);
       }
-      mwc-button.first-use {
+      .card-actions mwc-button.first-use {
         --mdc-theme-primary: var(--update-available-color);
       }
     `,

--- a/web.esphome.io/src/dashboard/pico-connect-card.ts
+++ b/web.esphome.io/src/dashboard/pico-connect-card.ts
@@ -89,6 +89,9 @@ class EWPicoConnectCard extends LitElement {
       esphome-card {
         --status-color: var(--alert-warning-color);
       }
+      .card-actions mwc-button {
+        --mdc-theme-primary: var(--card-text-color);
+      }
       mwc-list-item {
         --mdc-list-side-padding: 14px;
       }

--- a/web.esphome.io/src/dashboard/pico-device-card.ts
+++ b/web.esphome.io/src/dashboard/pico-device-card.ts
@@ -73,7 +73,10 @@ class EWPicoDeviceCard extends LitElement {
     esphomeCardStyles,
     css`
       esphome-card {
-        --status-color: var(--card-status-color);
+        --status-color: var(--card-text-color);
+      }
+      .card-actions mwc-button {
+        --mdc-theme-primary: var(--card-text-color);
       }
     `,
   ];

--- a/web.esphome.io/src/dashboard/pico-device-card.ts
+++ b/web.esphome.io/src/dashboard/pico-device-card.ts
@@ -73,7 +73,7 @@ class EWPicoDeviceCard extends LitElement {
     esphomeCardStyles,
     css`
       esphome-card {
-        --status-color: rgba(0, 0, 0, 0.5);
+        --status-color: var(--card-status-color);
       }
     `,
   ];

--- a/web.esphome.io/src/dashboard/unsupported-card.ts
+++ b/web.esphome.io/src/dashboard/unsupported-card.ts
@@ -23,6 +23,9 @@ class EWUnsupportedCard extends LitElement {
       esphome-card {
         --status-color: var(--alert-error-color);
       }
+      .card-actions mwc-button {
+        --mdc-theme-primary: var(--card-text-color);
+      }
     `,
   ];
 }


### PR DESCRIPTION
I was unable to get the full esphome stack running on my windows machine, but was able to host a small local web server with the static files in the [web.esphome.io](https://github.com/esphome/dashboard/tree/main/web.esphome.io) folder. This uses the user's `prefers-color-scheme: dark` setting to change some css values so it is a bit better on the eyes. This should close https://github.com/esphome/dashboard/issues/347.


Here are some screenshots:

![screencapture-127-0-0-1-8080-2023-02-05-03_11_45](https://user-images.githubusercontent.com/2222562/216808560-649aad9b-b251-4f87-a782-bc8512b8e73f.png)

![screencapture-127-0-0-1-8080-2023-02-05-03_12_16](https://user-images.githubusercontent.com/2222562/216808561-a4ac7d0d-a31b-4acd-aaa6-cee359f755e7.png)


I was thus unable to test any screens past these ones, so the editor will still be the light theme.
I believe this would require changing the following code.
Maybe this should be a config setting, or maybe [check with js](https://stackoverflow.com/a/57795495/7718197) and toggle to `vs-dark` with a darker `editor.foreground`?
https://github.com/esphome/dashboard/blob/e60c7d936de424b9360ab892317723c4277404af/src/editor/monaco-provider.ts#L57-L65
