### PR TITLE
Fix opening install dialog from Wizard

### DIFF
--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -503,8 +503,7 @@ export class ESPHomeWizardDialog extends LitElement {
               slot="primaryAction"
               dialogAction="ok"
               label="Install"
-              @click=${() =>
-                openInstallChooseDialog(`${this._data.name!}.yaml`)}
+              @click=${() => openInstallChooseDialog(this._configFilename)}
             ></mwc-button>
             <mwc-button
               no-attention


### PR DESCRIPTION
The install dialog opened from the Wizard was broken. This fixes it.