### PR TITLE
Small fixes

### DIFF
--- a/src/components/process-dialog.ts
+++ b/src/components/process-dialog.ts
@@ -12,7 +12,13 @@ import { basename } from "../util/basename";
 export class ESPHomeProcessDialog extends LitElement {
   @property() public heading!: string;
   @property() public spawnParams?: Record<string, any>;
-  @property() public type!: string;
+  @property() public type!:
+    | "validate"
+    | "logs"
+    | "upload"
+    | "clean-mqtt"
+    | "clean"
+    | "rename";
 
   @property({ type: Boolean, attribute: "always-show-close" })
   public alwaysShowClose = false;

--- a/src/components/remote-process.ts
+++ b/src/components/remote-process.ts
@@ -5,7 +5,13 @@ import { fireEvent } from "../util/fire-event";
 
 @customElement("esphome-remote-process")
 class ESPHomeRemoteProcess extends HTMLElement {
-  public type!: "validate" | "logs" | "upload" | "clean-mqtt" | "clean";
+  public type!:
+    | "validate"
+    | "logs"
+    | "upload"
+    | "clean-mqtt"
+    | "clean"
+    | "rename";
   public spawnParams!: Record<string, any>;
 
   private _coloredConsole?: ColoredConsole;

--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -226,7 +226,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
         padding: 0.2em 0.4em;
         margin: 0;
         font-size: 85%;
-        background-color: var(--card-background-color)
+        background-color: var(--card-background-color);
         border-radius: 3px;
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
           Courier, monospace;

--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -267,7 +267,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
           <mwc-circular-progress
             active
             ?indeterminate=${progress === undefined}
-            .progress=${progress !== undefined ? progress / 100 : undefined}
+            .progress=${progress !== undefined ? progress / 100 : 1}
             density="8"
           ></mwc-circular-progress>
           ${progress !== undefined

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -126,7 +126,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
           <mwc-circular-progress
             active
             ?indeterminate=${progress === undefined}
-            .progress=${progress !== undefined ? progress / 100 : undefined}
+            .progress=${progress !== undefined ? progress / 100 : 1}
             density="8"
           ></mwc-circular-progress>
           ${progress !== undefined

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -171,7 +171,7 @@ export class ESPHomeWizardDialog extends LitElement {
           <mwc-circular-progress
             active
             ?indeterminate=${progress === undefined}
-            .progress=${progress !== undefined ? progress / 100 : undefined}
+            .progress=${progress !== undefined ? progress / 100 : 1}
             density="8"
           ></mwc-circular-progress>
           ${progress !== undefined
@@ -332,7 +332,9 @@ export class ESPHomeWizardDialog extends LitElement {
               .platform=${key}
               @click=${this._handlePickPlatformClick}
             >
-              <span>${supportedPlatforms[key].label}</span>
+              <span
+                >${supportedPlatforms[key as SupportedPlatforms].label}</span
+              >
               ${metaChevronRight}
             </mwc-list-item>
           `


### PR DESCRIPTION
While browsing the code in VS I noticed some small places that showed errors when I removed `ignoreDeprecations` in tsconfig.

I've added the missing semicolon in src/devices/configured-device-card.ts and also adjusted the type property in src/components/process-dialog.ts and src/components/remote-process.ts
There was a missing cast in src/wizard/wizard-dialog.ts, so I've also added it.