### PR TITLE
remove use of npm legacy peer deps

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 16
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
       - name: Run Build
         run: web.esphome.io/script/build_web
       - name: Upload GitHub Pages artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v3.8.1
         with:
           node-version: 16
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: tsc
       - run: script/build
       - run: web.esphome.io/script/build_web

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.6.0
-      - name: Use Node.js 
+      - name: Use Node.js
         uses: actions/setup-node@v3.8.1
         with:
           node-version: 16
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: script/build
       - name: Build and publish
         env:


### PR DESCRIPTION
Completes #525 as the 
`--legacy-peer-deps` option is still in use in github build actions