### PR TITLE
Prepare for ESP32-C6 support

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -15,7 +15,7 @@ export type SupportedPlatforms =
 export type PlatformData = {
   label: string;
   showInPickerTitle: boolean;
-  showInDeviceType: boolean;
+  showInDeviceTypePicker: boolean;
   defaultBoard: string | null;
 };
 
@@ -25,43 +25,43 @@ export const supportedPlatforms: { [key in SupportedPlatforms]: PlatformData } =
     ESP32: {
       label: "ESP32",
       showInPickerTitle: true,
-      showInDeviceType: true,
+      showInDeviceTypePicker: true,
       defaultBoard: "esp32dev",
     },
     ESP32S2: {
       label: "ESP32-S2",
       showInPickerTitle: true,
-      showInDeviceType: true,
+      showInDeviceTypePicker: true,
       defaultBoard: "esp32-s2-saola-1",
     },
     ESP32S3: {
       label: "ESP32-S3",
       showInPickerTitle: true,
-      showInDeviceType: true,
+      showInDeviceTypePicker: true,
       defaultBoard: "esp32-s3-devkitc-1",
     },
     ESP32C3: {
       label: "ESP32-C3",
       showInPickerTitle: true,
-      showInDeviceType: true,
+      showInDeviceTypePicker: true,
       defaultBoard: "esp32-c3-devkitm-1",
     },
     ESP32C6: {
       label: "ESP32-C6",
       showInPickerTitle: true,
-      showInDeviceType: false,
+      showInDeviceTypePicker: false,
       defaultBoard: "esp32-c6-devkitc-1",
     },
     ESP8266: {
       label: "ESP8266",
       showInPickerTitle: true,
-      showInDeviceType: true,
+      showInDeviceTypePicker: true,
       defaultBoard: "esp01_1m",
     },
     RP2040: {
       label: "Raspberry Pi Pico W",
       showInPickerTitle: false,
-      showInDeviceType: true,
+      showInDeviceTypePicker: true,
       defaultBoard: "rpipicow",
     },
   };

--- a/src/const.ts
+++ b/src/const.ts
@@ -9,11 +9,13 @@ export type SupportedPlatforms =
   | "ESP32S2"
   | "ESP32S3"
   | "ESP32C3"
+  | "ESP32C6"
   | "RP2040";
 
 export type PlatformData = {
   label: string;
   showInPickerTitle: boolean;
+  showInDeviceType: boolean;
   defaultBoard: string | null;
 };
 
@@ -23,31 +25,43 @@ export const supportedPlatforms: { [key in SupportedPlatforms]: PlatformData } =
     ESP32: {
       label: "ESP32",
       showInPickerTitle: true,
+      showInDeviceType: true,
       defaultBoard: "esp32dev",
     },
     ESP32S2: {
       label: "ESP32-S2",
       showInPickerTitle: true,
+      showInDeviceType: true,
       defaultBoard: "esp32-s2-saola-1",
     },
     ESP32S3: {
       label: "ESP32-S3",
       showInPickerTitle: true,
+      showInDeviceType: true,
       defaultBoard: "esp32-s3-devkitc-1",
     },
     ESP32C3: {
       label: "ESP32-C3",
       showInPickerTitle: true,
+      showInDeviceType: true,
       defaultBoard: "esp32-c3-devkitm-1",
+    },
+    ESP32C6: {
+      label: "ESP32-C6",
+      showInPickerTitle: true,
+      showInDeviceType: false,
+      defaultBoard: "esp32-c6-devkitc-1",
     },
     ESP8266: {
       label: "ESP8266",
       showInPickerTitle: true,
+      showInDeviceType: true,
       defaultBoard: "esp01_1m",
     },
     RP2040: {
       label: "Raspberry Pi Pico W",
       showInPickerTitle: false,
+      showInDeviceType: true,
       defaultBoard: "rpipicow",
     },
   };
@@ -58,6 +72,7 @@ export const chipFamilyToPlatform: { [key: string]: SupportedPlatforms } = {
   "ESP32-S2": "ESP32S2",
   "ESP32-S3": "ESP32S3",
   "ESP32-C3": "ESP32C3",
+  "ESP32-C6": "ESP32C6",
   ESP8266: "ESP8266",
 };
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -326,7 +326,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
       <mwc-list class="platforms">
         ${Object.keys(supportedPlatforms).map((key) =>
-          supportedPlatforms[key].showInDeviceType
+          supportedPlatforms[key].showInDeviceTypePicker
             ? html`
                 <mwc-list-item
                   hasMeta

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -325,17 +325,19 @@ export class ESPHomeWizardDialog extends LitElement {
       </div>
 
       <mwc-list class="platforms">
-        ${Object.keys(supportedPlatforms).map(
-          (key) => supportedPlatforms[key].showInDeviceType ? html`
-            <mwc-list-item
-              hasMeta
-              .platform=${key}
-              @click=${this._handlePickPlatformClick}
-            >
-              <span>${supportedPlatforms[key].label}</span>
-              ${metaChevronRight}
-            </mwc-list-item>
-          `: html``,
+        ${Object.keys(supportedPlatforms).map((key) =>
+          supportedPlatforms[key].showInDeviceType
+            ? html`
+                <mwc-list-item
+                  hasMeta
+                  .platform=${key}
+                  @click=${this._handlePickPlatformClick}
+                >
+                  <span>${supportedPlatforms[key].label}</span>
+                  ${metaChevronRight}
+                </mwc-list-item>
+              `
+            : html``,
         )}
       </mwc-list>
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -326,7 +326,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
       <mwc-list class="platforms">
         ${Object.keys(supportedPlatforms).map(
-          (key) => html`
+          (key) => supportedPlatforms[key].showInDeviceType ? html`
             <mwc-list-item
               hasMeta
               .platform=${key}
@@ -335,7 +335,7 @@ export class ESPHomeWizardDialog extends LitElement {
               <span>${supportedPlatforms[key].label}</span>
               ${metaChevronRight}
             </mwc-list-item>
-          `,
+          `: html``,
         )}
       </mwc-list>
 


### PR DESCRIPTION
This adds the C6 to the supported platforms "list" and also adds a new key/value for removing items from the wizard. 

I started by adding to the `SupportedPlatforms` so that `chipFamilyToPlatform` could map it, but then typescript said I had to implement in the `supportedPlatforms` object too.

So in terms of user facing changes, it is not shown in the wizard yet, but will allow web-flashing of a C6 configuration.