### PR TITLE
Fix node resolve for esptool-js

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,7 +24,7 @@ const config = {
     entryFileNames: isProdBuild ? "[name]-[hash].js" : "[name].js",
     chunkFileNames: isProdBuild ? "c.[hash].js" : "[name].js",
     assetFileNames: isProdBuild ? "a.[hash].js" : "[name].js",
-    sourcemap: true
+    sourcemap: true,
   },
   preserveEntrySignatures: false,
   plugins: [
@@ -39,7 +39,7 @@ const config = {
             fs.ensureDirSync(distFontsPath);
             const targetFontPath = path.join(
               "esphome_dashboard/static/fonts/",
-              asset.pathname
+              asset.pathname,
             );
             fs.copySync(asset.absolutePath, targetFontPath);
             return "./static/fonts/" + asset.pathname;
@@ -56,7 +56,10 @@ const config = {
       languages: ["yaml"],
       sourcemap: false,
     }),
-    nodeResolve(),
+    nodeResolve({
+      browser: true,
+      preferBuiltins: false,
+    }),
     commonjs(),
     json(),
     manifest(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
     "ignoreDeprecations": "5.0",
-    "importHelpers": true
-  }
+    "importHelpers": true,
+  },
 }


### PR DESCRIPTION
esptool-js added a node-js package as a dependency. [Still trying to understand the reasoning](https://github.com/espressif/esptool-js/issues/130). For now, let's make sure the right import is used.