### PR TITLE
add publish command

### DIFF
--- a/src/components/remote-process.ts
+++ b/src/components/remote-process.ts
@@ -5,7 +5,7 @@ import { fireEvent } from "../util/fire-event";
 
 @customElement("esphome-remote-process")
 class ESPHomeRemoteProcess extends HTMLElement {
-  public type!: "validate" | "logs" | "upload" | "clean-mqtt" | "clean";
+  public type!: "validate" | "logs" | "upload" | "clean-mqtt" | "clean" | "publish";
   public spawnParams!: Record<string, any>;
 
   private _coloredConsole?: ColoredConsole;

--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -23,6 +23,7 @@ import { openShowApiKeyDialog } from "../show-api-key";
 import { openEditDialog } from "../editor";
 import { getFile } from "../api/files";
 import { textDownload } from "../util/file-download";
+import { openPublishDialog } from "../publish";
 import {
   mdiBroom,
   mdiCodeBraces,
@@ -31,6 +32,7 @@ import {
   mdiRenameBox,
   mdiSpellcheck,
   mdiUploadNetwork,
+  mdiPublish,
 } from "@mdi/js";
 
 const UPDATE_TO_ICON = "➡️";
@@ -183,6 +185,13 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
                 .path=${mdiBroom}
               ></esphome-svg-icon>
             </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              Publish
+              <esphome-svg-icon
+                slot="graphic"
+                .path=${mdiPublish}
+              ></esphome-svg-icon>
+            </mwc-list-item>
             <li divider role="separator"></li>
             <mwc-list-item class="warning" graphic="icon">
               Delete
@@ -270,6 +279,9 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
         openCleanDialog(this.device.configuration);
         break;
       case 6:
+        openPublishDialog(this.device.configuration);
+        break;
+      case 7:
         openDeleteDeviceDialog(
           this.device.name,
           this.device.configuration,

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -1,0 +1,8 @@
+const preload = () => import("./publish-dialog");
+
+export const openPublishDialog = (configuration: string) => {
+  preload();
+  const dialog = document.createElement("esphome-publish-dialog");
+  dialog.configuration = configuration;
+  document.body.append(dialog);
+};

--- a/src/publish/publish-dialog.ts
+++ b/src/publish/publish-dialog.ts
@@ -1,0 +1,57 @@
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import "@material/mwc-button";
+import "../components/remote-process";
+import { openInstallChooseDialog } from "../install-choose";
+import "../components/process-dialog";
+import { openEditDialog } from "../editor";
+import { esphomeDialogStyles } from "../styles";
+
+@customElement("esphome-publish-dialog")
+class ESPHomePublishDialog extends LitElement {
+  @property() public configuration!: string;
+
+  protected render() {
+    return html`
+      <esphome-process-dialog
+        .heading=${`Publish ${this.configuration}`}
+        .type=${"publish"}
+        .spawnParams=${{ configuration: this.configuration }}
+        @closed=${this._handleClose}
+      >
+        <mwc-button
+          slot="secondaryAction"
+          dialogAction="close"
+          label="Edit"
+          @click=${this._openEdit}
+        ></mwc-button>
+        <mwc-button
+          slot="secondaryAction"
+          dialogAction="close"
+          label="Install"
+          @click=${this._openInstall}
+        ></mwc-button>
+      </esphome-process-dialog>
+    `;
+  }
+
+  private _openEdit() {
+    openEditDialog(this.configuration);
+  }
+
+  private _openInstall() {
+    openInstallChooseDialog(this.configuration);
+  }
+
+  private _handleClose() {
+    this.parentNode!.removeChild(this);
+  }
+
+  static styles = [esphomeDialogStyles];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-publish-dialog": ESPHomePublishDialog;
+  }
+}


### PR DESCRIPTION
This PR add a 'Publish' command that run `esphome publish config.yaml --directory /config/www`, so the user can copy the firmware to the integrated http server of home assistant.

The firmware file could now be fetched by the device with OTA over http https://github.com/esphome/esphome/pull/5586

The `publish` command is defined in this PR: https://github.com/esphome/esphome/pull/6477