### PR TITLE
Add LibreTiny platforms to wizard dialog

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -10,7 +10,9 @@ export type SupportedPlatforms =
   | "ESP32S3"
   | "ESP32C3"
   | "ESP32C6"
-  | "RP2040";
+  | "RP2040"
+  | "BK72XX"
+  | "RTL87XX";
 
 export type PlatformData = {
   label: string;
@@ -63,6 +65,18 @@ export const supportedPlatforms: { [key in SupportedPlatforms]: PlatformData } =
       showInPickerTitle: false,
       showInDeviceTypePicker: true,
       defaultBoard: "rpipicow",
+    },
+    BK72XX: {
+      label: "BK72xx",
+      showInPickerTitle: true,
+      showInDeviceTypePicker: true,
+      defaultBoard: null,
+    },
+    RTL87XX: {
+      label: "RTL87xx",
+      showInPickerTitle: true,
+      showInDeviceTypePicker: true,
+      defaultBoard: null,
     },
   };
 


### PR DESCRIPTION
The PR adds LibreTiny platforms `BK72xx` and `RTL87xx` to the wizard device type picker.

![obraz](https://github.com/esphome/dashboard/assets/30433568/901ea0b5-6342-4e96-8545-7be893bab26a)
