### PR TITLE
Create TimestampTransformer and use it in EwtConsole

### DIFF
--- a/src/logs-webserial/ewt-console.ts
+++ b/src/logs-webserial/ewt-console.ts
@@ -1,6 +1,7 @@
 import { ColoredConsole, coloredConsoleStyles } from "../util/console-color";
 import { sleep } from "../util/sleep";
 import { LineBreakTransformer } from "../util/line-break-transformer";
+import { TimestampTransformer } from "../util/timestamp-transformer";
 import { Logger } from "../const";
 
 export class EwtConsole extends HTMLElement {
@@ -95,6 +96,7 @@ export class EwtConsole extends HTMLElement {
           signal: abortSignal,
         })
         .pipeThrough(new TransformStream(new LineBreakTransformer()))
+        .pipeThrough(new TransformStream(new TimestampTransformer()))
         .pipeTo(
           new WritableStream({
             write: (chunk) => {

--- a/src/util/timestamp-transformer.ts
+++ b/src/util/timestamp-transformer.ts
@@ -4,9 +4,9 @@ export class TimestampTransformer implements Transformer<string, string> {
     controller: TransformStreamDefaultController<string>,
   ) {
     const date = new Date();
-    const h = date.getHours().toString().padStart(2, '0');
-    const m = date.getMinutes().toString().padStart(2, '0');
-    const s = date.getSeconds().toString().padStart(2, '0');
+    const h = date.getHours().toString().padStart(2, "0");
+    const m = date.getMinutes().toString().padStart(2, "0");
+    const s = date.getSeconds().toString().padStart(2, "0");
     controller.enqueue(`[${h}:${m}:${s}]${chunk}`);
   }
 }

--- a/src/util/timestamp-transformer.ts
+++ b/src/util/timestamp-transformer.ts
@@ -1,0 +1,12 @@
+export class TimestampTransformer implements Transformer<string, string> {
+  transform(
+    chunk: string,
+    controller: TransformStreamDefaultController<string>,
+  ) {
+    const date = new Date();
+    const h = date.getHours().toString().padStart(2, '0');
+    const m = date.getMinutes().toString().padStart(2, '0');
+    const s = date.getSeconds().toString().padStart(2, '0');
+    controller.enqueue(`[${h}:${m}:${s}]${chunk}`);
+  }
+}


### PR DESCRIPTION
This creates `TimestampTransformer` which processes the incoming chunks (lines) and prepends a timestamp of the form `[HH:MM:SS]`

## ewt-console
![ewt-console](https://github.com/esphome/dashboard/assets/706138/24255789-8139-4bb5-89b4-61040de46d00)

## `esphome logs ...`
![esphome logs](https://github.com/esphome/dashboard/assets/706138/946d32e7-0075-401d-8c1a-af94db4af479)

