### PR TITLE
Use PORT env var to customize script/develop_web port

### DIFF
--- a/web.esphome.io/script/develop_web
+++ b/web.esphome.io/script/develop_web
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z "$PORT" ]; then
+  PORT=5006
+fi
+
 # Stop on errors
 set -e
 
@@ -16,7 +20,7 @@ node build/render-index.mjs
 # Quit all background tasks when script exits
 trap "kill 0" EXIT
 
-npm exec -- serve -p 5006 dist &
+npm exec -- serve -p "$PORT" dist &
 
 cd ..
 


### PR DESCRIPTION
This allows the port used by `npm run develop_web` to be customized by setting the `PORT` env var, e.g:
```
> PORT=5432 npm run develop_web

   ┌────────────────────────────────────────┐
   │                                        │
   │   Serving!                             │
   │                                        │
   │   - Local:    http://localhost:5432    │
   │   - Network:  http://10.0.0.10:5432    │
   │                                        │
   │   Copied local address to clipboard!   │
   │                                        │
   └────────────────────────────────────────┘
```
Otherwise defaults to the current 5006