### PR TITLE
Fix logo height header

### DIFF
--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -112,7 +112,7 @@ esphome-main {
 
 .esphome-header img {
   width: auto;
-  height: 48px;
+  height: 38px;
 }
 
 #js-loading-indicator {
@@ -187,9 +187,6 @@ ul.browser-default li {
   .esphome-header {
     height: 52px;
     padding: 0 8px;
-  }
-  .esphome-header img {
-    height: 38px;
   }
   main {
     margin-top: 52px;


### PR DESCRIPTION
The new logo was a bit too tall for the header, this reduces the height.

Before:
<img width="795" alt="image" src="https://github.com/esphome/dashboard/assets/1444314/f7ffaba4-ba48-495e-b56d-c9c2fd45a4fe">


After:
<img width="282" alt="image" src="https://github.com/esphome/dashboard/assets/1444314/9ca66c27-ae41-4b70-8726-6733dc6e2e3e">
