### PR TITLE
Make update available less obtrusive

### DIFF
--- a/raw_package/static/css/esphome-2.css
+++ b/raw_package/static/css/esphome-2.css
@@ -24,7 +24,7 @@
   --mdc-theme-on-primary: white;
   --mdc-dialog-heading-ink-color: #212121;
   --mdc-dialog-content-ink-color: #212121;
-  --update-available-color: #2e3dd4;
+  --highlight-button-color: #2e3dd4;
   --status-connected: #444444;
   --status-new: #ffa500;
   --status-imported: #4caf50;
@@ -52,7 +52,7 @@
     --mdc-ripple-color: #282828;
     --mdc-text-field-fill-color: #3d3d3d;
     --mdc-theme-text-secondary-on-background: #e1e1e1;
-    --update-available-color: #5f7eeb;
+    --highlight-button-color: #5f7eeb;
     --status-connected: #cecece;
     --mdc-ripple-color: #bebebe;
   }

--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -37,7 +37,6 @@ const UPDATE_TO_ICON = "➡️";
 const STATUS_COLORS = {
   NEW: "var(--status-new)",
   OFFLINE: "var(--alert-error-color)",
-  "UPDATE AVAILABLE": "var(--update-available-color)",
   ONLINE: "var(--status-connected)",
 };
 
@@ -81,11 +80,9 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
     const updateAvailable = canUpdateDevice(this.device);
     const status = this._highlight
       ? "NEW"
-      : this.onlineStatus && updateAvailable
-        ? "UPDATE AVAILABLE"
-        : this.onlineStatus
-          ? "ONLINE"
-          : "OFFLINE";
+      : this.onlineStatus
+        ? "ONLINE"
+        : "OFFLINE";
     return html`
       <esphome-card
         .status=${status}
@@ -108,7 +105,6 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
                 <div class="tooltip-container">
                   <mwc-button
                     @click=${this._handleInstall}
-                    class="update-available"
                     icon="system_update"
                     label="Update"
                   ></mwc-button>
@@ -230,9 +226,6 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
         border-radius: 3px;
         font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
           Courier, monospace;
-      }
-      .card-actions mwc-button.update-available {
-        --mdc-theme-primary: var(--update-available-color);
       }
       esphome-button-menu {
         --mdc-theme-text-icon-on-background: var(--primary-text-color);

--- a/web.esphome.io/src/dashboard/esp-device-card.ts
+++ b/web.esphome.io/src/dashboard/esp-device-card.ts
@@ -114,7 +114,7 @@ class EWESPDeviceCard extends LitElement {
         --mdc-theme-text-icon-on-background: var(--primary-text-color);
       }
       mwc-button.first-use {
-        --mdc-theme-primary: var(--update-available-color);
+        --mdc-theme-primary: var(--highlight-button-color);
       }
     `,
   ];


### PR DESCRIPTION
When an update is available, we don't give the card a status bar anymore and override the online status. We also won't color the update button anymore.

![image](https://github.com/esphome/dashboard/assets/1444314/0ef69118-fe4b-4538-9de7-0600d13188d9)
