### PR TITLE
Fix esphome-web firmware file url

### DIFF
--- a/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
+++ b/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
@@ -65,7 +65,7 @@ class ESPHomeInstallAdoptableDialog extends LitElement {
           }
           const platformLower = platform.toLowerCase();
           const resp = await fetch(
-            `https://firmware.esphome.io/esphome-web/${platformLower}/esphome-web-${platformLower}.bin`,
+            `https://firmware.esphome.io/esphome-web/${platformLower}/esphome-web-${platformLower}.factory.bin`,
           );
           if (!resp.ok) {
             throw new Error(


### PR DESCRIPTION
We changed the binary filenames and I didnt realise this was using "hardcoded" filename instead of downloading the manifest.json and using that :see_no_evil: 