### PR TITLE
Make build scripts portable

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stop on errors
 set -e

--- a/script/develop
+++ b/script/develop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stop on errors
 set -e

--- a/script/sync-vscode
+++ b/script/sync-vscode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copies all files which are shared between vscode and dashboard editor
 

--- a/web.esphome.io/script/build_web
+++ b/web.esphome.io/script/build_web
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stop on errors
 set -e

--- a/web.esphome.io/script/develop_web
+++ b/web.esphome.io/script/develop_web
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$PORT" ]; then
   PORT=5006


### PR DESCRIPTION
This allows looking up the path to bash from the PATH environment variable, as opposed to hardcoding its path in the shebang.