### PR TITLE
Add url to the editor

### DIFF
--- a/src/esphome-main.ts
+++ b/src/esphome-main.ts
@@ -12,7 +12,8 @@ class ESPHomeMainView extends LitElement {
 
   @property() logoutUrl?: string;
 
-  @state() private editing?: string;
+  private url = new URL(document.baseURI);
+  @state() private editing?: string = this.url.searchParams.get("edit") || undefined;
 
   protected render() {
     if (this.editing) {
@@ -63,13 +64,25 @@ class ESPHomeMainView extends LitElement {
 
   protected firstUpdated(changedProps: PropertyValues): void {
     super.firstUpdated(changedProps);
+
     document.body.addEventListener<any>("edit-file", (ev) => {
+      this.url.searchParams.set("edit", ev.detail);
+      window.history.pushState({}, "", this.url.toString());
       this.editing = ev.detail;
     });
+
+    window.addEventListener("popstate", () => {
+      const url = new URL(document.baseURI);
+      const editing = url.searchParams.get("edit") || undefined;
+      this.editing = editing;
+    })
+
     import("./editor/esphome-editor");
   }
 
   private _handleEditorClose() {
+    this.url.searchParams.delete("edit");
+    window.history.pushState({}, "", this.url.toString());
     this.editing = undefined;
   }
 }


### PR DESCRIPTION
This PR adds a `?edit=filename.yaml` search query to the page URL. This allows users to navigate back and forth between pages and keeping the editor open. Additionally, refreshing the page will open the editor and each file has its own specific URL based on `filename.yaml`.

Additionally, this change lays the groundwork for future implementation of an unsaved changes alert that will be triggered when a user attempts to close the browser tab or refresh the page while there are unsaved modifications in the editor.