### PR TITLE
Get firmware version from latest manifest

### DIFF
--- a/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
+++ b/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
@@ -63,9 +63,20 @@ class ESPHomeInstallAdoptableDialog extends LitElement {
               )} are supported.`,
             );
           }
+
+          const manifestResp = await fetch(
+            "https://firmware.esphome.io/esphome-web/manifest.json",
+          );
+          if (!manifestResp.ok) {
+            throw new Error(
+              `Downloading ESPHome manifest failed (${manifestResp.status})`,
+            );
+          }
+          const version = (await manifestResp.json())["version"];
+
           const platformLower = platform.toLowerCase();
           const resp = await fetch(
-            `https://firmware.esphome.io/esphome-web/${platformLower}/esphome-web-${platformLower}.factory.bin`,
+            `https://firmware.esphome.io/esphome-web/${version}/esphome-web-${platformLower}.factory.bin`,
           );
           if (!resp.ok) {
             throw new Error(


### PR DESCRIPTION
With a restructure to how ESPHome deploys firmware, the binaries are now located in a sub-directory of the version.