### PR TITLE
Hide discovered devices by default

### DIFF
--- a/src/components/esphome-header-menu.ts
+++ b/src/components/esphome-header-menu.ts
@@ -18,7 +18,9 @@ const isWideListener = window.matchMedia("(min-width: 641px)");
 export class ESPHomeHeaderMenu extends LitElement {
   @property({ type: String, attribute: "logout-url" }) logoutUrl?: string;
 
-  @property() showIgnoredDevices = false;
+  @property() showDiscoveredDevices = false;
+
+  @property() discoveredDeviceCount = 0;
 
   @state() private _isWide = isWideListener.matches;
 
@@ -57,9 +59,9 @@ export class ESPHomeHeaderMenu extends LitElement {
 
         <mwc-list-item graphic="icon"
           ><mwc-icon slot="graphic">filter_list</mwc-icon>
-          ${this.showIgnoredDevices
-            ? "Hide ignored devices"
-            : "Show ignored devices"}
+          ${this.showDiscoveredDevices
+            ? "Hide discovered devices"
+            : "Show discovered devices"}
         </mwc-list-item>
 
         ${!this._isWide
@@ -125,7 +127,7 @@ export class ESPHomeHeaderMenu extends LitElement {
     if (this._isWide) {
       switch (ev.detail.index) {
         case 0:
-          fireEvent(this, "toggle-ignored-devices");
+          fireEvent(this, "toggle-discovered-devices");
           break;
       }
       return;
@@ -135,7 +137,7 @@ export class ESPHomeHeaderMenu extends LitElement {
         this._handleSearch();
         break;
       case 1:
-        fireEvent(this, "toggle-ignored-devices");
+        fireEvent(this, "toggle-discovered-devices");
         break;
       case 2:
         this._handleUpdateAll();

--- a/src/devices/importable-device-card.ts
+++ b/src/devices/importable-device-card.ts
@@ -17,7 +17,10 @@ class ESPHomeImportableDeviceCard extends LitElement {
 
   protected render() {
     return html`
-      <esphome-card status="DISCOVERED" ?ignored=${this.device.ignored}>
+      <esphome-card
+        .status=${this.device.ignored ? "IGNORED DISCOVERY" : "DISCOVERED"}
+        ?ignored=${this.device.ignored}
+      >
         <div class="card-header">
           ${this.device.friendly_name || this.device.name}
         </div>

--- a/src/esphome-main.ts
+++ b/src/esphome-main.ts
@@ -14,8 +14,7 @@ class ESPHomeMainView extends LitElement {
 
   @state() private editing?: string;
 
-  // temp for development set ot true
-  @state() private showIgnoredDevices = true;
+  @state() private showDiscoveredDevices = false;
 
   protected render() {
     if (this.editing) {
@@ -39,14 +38,15 @@ class ESPHomeMainView extends LitElement {
         <div class="flex"></div>
         <esphome-header-menu
           .logoutUrl=${this.logoutUrl}
-          .showIgnoredDevices=${this.showIgnoredDevices}
-          @toggle-ignored-devices=${this._toggleIgnoredDevices}
+          .showDiscoveredDevices=${this.showDiscoveredDevices}
+          @toggle-discovered-devices=${this._toggleDiscoveredDevices}
         ></esphome-header-menu>
       </header>
 
       <main>
         <esphome-devices-list
-          .showIgnoredDevices=${this.showIgnoredDevices}
+          .showDiscoveredDevices=${this.showDiscoveredDevices}
+          @toggle-discovered-devices=${this._toggleDiscoveredDevices}
         ></esphome-devices-list>
       </main>
 
@@ -82,8 +82,8 @@ class ESPHomeMainView extends LitElement {
     this.editing = undefined;
   }
 
-  private _toggleIgnoredDevices() {
-    this.showIgnoredDevices = !this.showIgnoredDevices;
+  private _toggleDiscoveredDevices() {
+    this.showDiscoveredDevices = !this.showDiscoveredDevices;
   }
 }
 


### PR DESCRIPTION
Discovered devices are now hidden by default. If there are any, we will show a toolbar instead. If all discovered devices have been ignored, they will not be shown.

