### PR TITLE
Fix parsing of blocks

### DIFF
--- a/src/editor/monaco-provider.ts
+++ b/src/editor/monaco-provider.ts
@@ -265,16 +265,16 @@ monaco.languages.setMonarchTokensProvider("esphome", {
     ],
 
     // First line of a Block Style
-    multiString: [[/^( +).+$/, "string", "@multiStringContinued.$1"]],
+    multiString: [[/^([ \t]+).+$/, "string", "@multiStringContinued.$1"]],
 
     // Further lines of a Block Style
     //   Workaround for indentation detection
     multiStringContinued: [
       [
-        /^( *).+$/,
+        /^([ \t]*).+$/,
         {
           cases: {
-            "$1~$S2 *": "string",
+            "$1~$S2[ \t]*": "string",
             "@default": { token: "@rematch", next: "@popall" },
           },
         },

--- a/src/editor/monaco-provider.ts
+++ b/src/editor/monaco-provider.ts
@@ -274,7 +274,7 @@ monaco.languages.setMonarchTokensProvider("esphome", {
         /^( *).+$/,
         {
           cases: {
-            "$1==$S2": "string",
+            "$1~$S2 *": "string",
             "@default": { token: "@rematch", next: "@popall" },
           },
         },
@@ -308,7 +308,7 @@ monaco.languages.setMonarchTokensProvider("esphome", {
     ],
 
     // Start Block Scalar
-    blockStyle: [[/[>|][0-9]*[+-]?$/, "operators", "@multiString"]],
+    blockStyle: [[/[>|][0-9]*[+-]?[ \t]*$/, "operators", "@multiString"]],
 
     // Numbers in Flow Collections (terminate with ,]})
     flowNumber: [


### PR DESCRIPTION
Fix issues with parsing blocks:
- Right now every line needs to have the same indent. However C++ code inside a lambda will have varying indents. Instead of checking for a fixed indent check that the indent is greater than or equal to the indent on the first line. End the block only when the indent decreases. 
- The rest of the editor handles tabs except for the lambda/block part. Check for both tabs and spaces. 
- Allow whitespace after the block indicator. If there is a trailing space its not treated as a block and gets parsed as yaml.

Not only does the current parsing look bad it also confuses people into thinking indents in lambdas are not allowed. I have seen people post huge lambdas in discord without a single indent. 

Current HA addon, no whitespace after |-
![image](https://github.com/user-attachments/assets/d34c209a-fa49-4df1-a787-d0dd9bc5ab6b)

Current HA addon, with whitespace after |-
![image](https://github.com/user-attachments/assets/47dc790d-8ac3-4e35-a1a1-956338d51a11)

Fixed
![image](https://github.com/user-attachments/assets/c67db0c8-56dc-4424-8200-ad41a9072fbb)
