### PR TITLE
Rename dashboard to Device Builder

### DIFF
--- a/src/install-choose/install-choose-dialog.ts
+++ b/src/install-choose/install-choose-dialog.ts
@@ -83,7 +83,7 @@ class ESPHomeInstallChooseDialog extends LitElement {
         </mwc-list-item>
 
         <mwc-list-item twoline hasMeta @click=${this._handleServerInstall}>
-          <span>Plug into the computer running ESPHome Dashboard</span>
+          <span>Plug into the computer running ESPHome Device Builder</span>
           <span slot="secondary">
             ${`For devices connected via USB to the server${
               this._isPico ? " and running ESPHome" : ""


### PR DESCRIPTION
Rename ESPHome dashboard to ESPHome Device Builder.

![image](https://github.com/user-attachments/assets/e4b7e557-8fcb-4723-ac92-06155a4f7186)
