### PR TITLE
Add Pico to picoPortFilters

### DIFF
--- a/src/util/pico-port-filter.ts
+++ b/src/util/pico-port-filter.ts
@@ -1,6 +1,12 @@
 export const picoPortFilters: SerialPortRequestOptions["filters"] = [
   {
-    usbProductId: 61450,
-    usbVendorId: 11914,
+    // Pico (RP2040)
+    usbProductId: 0x000a,
+    usbVendorId: 0x2e8a,
+  },
+  {
+    // Pico W (RP2040)
+    usbProductId: 0xf00a,
+    usbVendorId: 0x2e8a,
   },
 ];


### PR DESCRIPTION
Tested with my Pico W (which shows up as `0x000A` 🤔) and it showed up
![serial port](https://github.com/user-attachments/assets/5c0393b0-d3b1-4115-a946-8caec228f459)

And successfully provisioned
![provisioned](https://github.com/user-attachments/assets/c3539007-954e-4c2e-a627-e1bcb6c3813d)
