### PR TITLE
improve esp32 schema

### DIFF
--- a/schema/esp32.json
+++ b/schema/esp32.json
@@ -138,6 +138,12 @@
                 "esp32-c3-m1i-kit": {
                   "docs": "Ai-Thinker ESP-C3-M1-I-Kit"
                 },
+                "esp32-c6-devkitc-1": {
+                  "docs": "Espressif ESP32-C6-DevKitC-1"
+                },
+                "esp32-c6-devkitm-1": {
+                  "docs": "Espressif ESP32-C6-DevKitM-1"
+                },
                 "esp32cam": {
                   "docs": "AI Thinker ESP32-CAM"
                 },
@@ -573,6 +579,16 @@
               },
               "docs": "**string**: The PlatformIO board ID that should be used. Choose the appropriate board from [this list](https://registry.platformio.org/packages/platforms/platformio/espressif32/boards) (the icon next to the name can be used to copy the board ID). *This only affects pin aliases, flash size and some internal settings*, if unsure choose a generic board from Espressif such as `esp32dev`.\n\n*See also: [ESP32 Platform](https://esphome.io/components/esp32.html#configuration-variables)*"
             },
+            "flash_size": {
+              "key": "Optional",
+              "type": "string",
+              "docs": "**string**: The amount of flash memory available on the ESP32 board/module. One of `2MB`, `4MB`, `8MB`, `16MB` or `32MB`. Defaults to `4MB`. **Warning: specifying a size larger than that available on your board will cause the ESP32 to fail to boot.**"
+            },
+            "partitions": {
+              "key": "Optional",
+              "type": "string",
+              "docs": "**string**: The name of (optionally including the path to) the file containing the partitioning scheme to be used. When not specified, partitions are automatically generated based on `flash_size`."
+            },
             "variant": {
               "key": "Optional",
               "type": "enum",
@@ -585,7 +601,7 @@
                 "ESP32C6": null,
                 "ESP32H2": null
               },
-              "docs": "**string**: The variant of the ESP32 that is used on this board. One of `esp32`, `esp32s2`, `esp32s3`, `esp32c3` and `esp32h2`. Defaults to the variant that is detected from the board, if a board that\u2019s unknown to ESPHome is used, this option is mandatory.\n\n*See also: [ESP32 Platform](https://esphome.io/components/esp32.html#configuration-variables)*"
+              "docs": "**string**: The variant of the ESP32 that is used on this board. One of `esp32`, `esp32s2`, `esp32s3`, `esp32c3`, `esp32c6` and `esp32h2`. Defaults to the variant that is detected from the board, if a board that\u2019s unknown to ESPHome is used, this option is mandatory.\n\n*See also: [ESP32 Platform](https://esphome.io/components/esp32.html#configuration-variables)*"
             },
             "framework": {
               "key": "Optional",
@@ -607,6 +623,7 @@
                     },
                     "platform_version": {
                       "key": "Optional",
+                      "type": "string",
                       "docs": "**string**: The version of the [platformio/espressif32](https://github.com/platformio/platform-espressif32/releases/) package to use.\n\n*See also: [ESP-IDF framework](https://esphome.io/components/esp32.html#id2)*"
                     },
                     "sdkconfig_options": {
@@ -688,6 +705,7 @@
                     },
                     "platform_version": {
                       "key": "Optional",
+                      "type": "string",
                       "docs": "**string**: The version of the [platformio/espressif32](https://github.com/platformio/platform-espressif32/releases/) package to use.\n\n*See also: [Arduino framework](https://esphome.io/components/esp32.html#id1)*"
                     }
                   }


### PR DESCRIPTION
- add schema definition for `flash_size` and `partitions`
- add missing type `string`
- add `esp32-c6` boards