### PR TITLE
add platforms and enable ESP32-C6 in device picker

### DIFF
--- a/schema/esp32.json
+++ b/schema/esp32.json
@@ -598,10 +598,13 @@
                 "ESP32S3": null,
                 "ESP32C2": null,
                 "ESP32C3": null,
+                "ESP32C5": null,
                 "ESP32C6": null,
-                "ESP32H2": null
+                "ESP32C61": null,
+                "ESP32H2": null,
+                "ESP32P4": null
               },
-              "docs": "**string**: The variant of the ESP32 that is used on this board. One of `esp32`, `esp32s2`, `esp32s3`, `esp32c3`, `esp32c6` and `esp32h2`. Defaults to the variant that is detected from the board, if a board that\u2019s unknown to ESPHome is used, this option is mandatory.\n\n*See also: [ESP32 Platform](https://esphome.io/components/esp32.html#configuration-variables)*"
+              "docs": "**string**: The variant of the ESP32 that is used on this board. One of `esp32`, `esp32s2`, `esp32s3`, `esp32c2`, `esp32c3`, `esp32c6`, `esp32h2` and `esp32p4`. Defaults to the variant that is detected from the board, if a board that\u2019s unknown to ESPHome is used, this option is mandatory.\n\n*See also: [ESP32 Platform](https://esphome.io/components/esp32.html#configuration-variables)*"
             },
             "framework": {
               "key": "Optional",

--- a/src/const.ts
+++ b/src/const.ts
@@ -8,8 +8,13 @@ export type SupportedPlatforms =
   | "ESP32"
   | "ESP32S2"
   | "ESP32S3"
+  | "ESP32C2"
   | "ESP32C3"
+  | "ESP32C5"
   | "ESP32C6"
+  | "ESP32C61"
+  | "ESP32H2"
+  | "ESP32P4"
   | "RP2040"
   | "BK72XX"
   | "RTL87XX";
@@ -41,17 +46,47 @@ export const supportedPlatforms = {
     showInDeviceTypePicker: true,
     defaultBoard: "esp32-s3-devkitc-1",
   },
+  ESP32C2: {
+    label: "ESP32-C2",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: false,
+    defaultBoard: "esp32-c2-devkitm-1",
+  },
   ESP32C3: {
     label: "ESP32-C3",
     showInPickerTitle: true,
     showInDeviceTypePicker: true,
     defaultBoard: "esp32-c3-devkitm-1",
   },
+  ESP32C5: {
+    label: "ESP32-C5",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: false,
+    defaultBoard: "esp32-c5-devkitc-1",
+  },
   ESP32C6: {
     label: "ESP32-C6",
     showInPickerTitle: true,
-    showInDeviceTypePicker: false,
+    showInDeviceTypePicker: true,
     defaultBoard: "esp32-c6-devkitc-1",
+  },
+  ESP32C61: {
+    label: "ESP32-C61",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: false,
+    defaultBoard: "esp32-c61-devkitc-1",
+  },
+  ESP32H2: {
+    label: "ESP32-H2",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: false,
+    defaultBoard: "esp32-h2-devkitm-1",
+  },
+  ESP32P4: {
+    label: "ESP32-P4",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: false,
+    defaultBoard: "esp32-p4-function-ev-board",
   },
   ESP8266: {
     label: "ESP8266",
@@ -84,8 +119,13 @@ export const chipFamilyToPlatform = {
   ESP32: "ESP32",
   "ESP32-S2": "ESP32S2",
   "ESP32-S3": "ESP32S3",
+  "ESP32-C2": "ESP32C2",
   "ESP32-C3": "ESP32C3",
+  "ESP32-C5": "ESP32C5",
   "ESP32-C6": "ESP32C6",
+  "ESP32-C61": "ESP32C61",
+  "ESP32-H2": "ESP32H2",
+  "ESP32-P4": "ESP32P4",
   ESP8266: "ESP8266",
 } as const satisfies { [key: string]: SupportedPlatforms };
 


### PR DESCRIPTION
- add platforms: `ESP32-C2`, `ESP32-C5`, `ESP32-C61`, `ESP32-H2`. `ESP32-P4`
- enable `ESP32-C6` in device picker