### PR TITLE
Platform/ChipFamily type improvements

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -22,73 +22,74 @@ export type PlatformData = {
 };
 
 // Platforms supported by ESPHome
-export const supportedPlatforms: { [key in SupportedPlatforms]: PlatformData } =
-  {
-    ESP32: {
-      label: "ESP32",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: "esp32dev",
-    },
-    ESP32S2: {
-      label: "ESP32-S2",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: "esp32-s2-saola-1",
-    },
-    ESP32S3: {
-      label: "ESP32-S3",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: "esp32-s3-devkitc-1",
-    },
-    ESP32C3: {
-      label: "ESP32-C3",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: "esp32-c3-devkitm-1",
-    },
-    ESP32C6: {
-      label: "ESP32-C6",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: false,
-      defaultBoard: "esp32-c6-devkitc-1",
-    },
-    ESP8266: {
-      label: "ESP8266",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: "esp01_1m",
-    },
-    RP2040: {
-      label: "Raspberry Pi Pico W",
-      showInPickerTitle: false,
-      showInDeviceTypePicker: true,
-      defaultBoard: "rpipicow",
-    },
-    BK72XX: {
-      label: "BK72xx",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: null,
-    },
-    RTL87XX: {
-      label: "RTL87xx",
-      showInPickerTitle: true,
-      showInDeviceTypePicker: true,
-      defaultBoard: null,
-    },
-  };
+export const supportedPlatforms = {
+  ESP32: {
+    label: "ESP32",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: "esp32dev",
+  },
+  ESP32S2: {
+    label: "ESP32-S2",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: "esp32-s2-saola-1",
+  },
+  ESP32S3: {
+    label: "ESP32-S3",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: "esp32-s3-devkitc-1",
+  },
+  ESP32C3: {
+    label: "ESP32-C3",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: "esp32-c3-devkitm-1",
+  },
+  ESP32C6: {
+    label: "ESP32-C6",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: false,
+    defaultBoard: "esp32-c6-devkitc-1",
+  },
+  ESP8266: {
+    label: "ESP8266",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: "esp01_1m",
+  },
+  RP2040: {
+    label: "Raspberry Pi Pico W",
+    showInPickerTitle: false,
+    showInDeviceTypePicker: true,
+    defaultBoard: "rpipicow",
+  },
+  BK72XX: {
+    label: "BK72xx",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: null,
+  },
+  RTL87XX: {
+    label: "RTL87xx",
+    showInPickerTitle: true,
+    showInDeviceTypePicker: true,
+    defaultBoard: null,
+  },
+} as const satisfies { [key in SupportedPlatforms]: PlatformData };
 
 // esploader.chip.CHIP_NAME mapped to ESPHome platform names
-export const chipFamilyToPlatform: { [key: string]: SupportedPlatforms } = {
+export const chipFamilyToPlatform = {
   ESP32: "ESP32",
   "ESP32-S2": "ESP32S2",
   "ESP32-S3": "ESP32S3",
   "ESP32-C3": "ESP32C3",
   "ESP32-C6": "ESP32C6",
   ESP8266: "ESP8266",
-};
+} as const satisfies { [key: string]: SupportedPlatforms };
+
+export type ChipFamily = keyof typeof chipFamilyToPlatform;
 
 export const metaChevronRight = svg`
   <svg class="svg-fill-primary" width="24" height="24" viewBox="0 0 24 24" slot="meta">

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -16,14 +16,16 @@ import {
 } from "../web-serial/flash";
 import { openCompileDialog } from "../compile";
 import { openInstallWebDialog } from ".";
-import { chipFamilyToPlatform } from "../const";
+import {
+  chipFamilyToPlatform,
+  SupportedPlatforms,
+  type ChipFamily,
+} from "../const";
 import { esphomeDialogStyles } from "../styles";
 import { sleep } from "../util/sleep";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
-
-type ValueOf<T> = T[keyof T];
 
 @customElement("esphome-install-web-dialog")
 export class ESPHomeInstallWebDialog extends LitElement {
@@ -32,9 +34,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
     port?: SerialPort;
     // Pass either a configuration or a filesCallback. filesCallback receives platform of ESP device.
     configuration?: string;
-    filesCallback?: (
-      platform: ValueOf<typeof chipFamilyToPlatform>,
-    ) => Promise<FileToFlash[]>;
+    filesCallback?: (platform: SupportedPlatforms) => Promise<FileToFlash[]>;
     // Should the device be erased before installation
     erase?: boolean;
     // Callback when the dialog is closed. Note that if success is false,
@@ -54,7 +54,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
 
   @state() private _error?: string | TemplateResult;
 
-  private _platform?: ValueOf<typeof chipFamilyToPlatform>;
+  private _platform?: SupportedPlatforms;
 
   protected render() {
     let heading;
@@ -196,11 +196,12 @@ export class ESPHomeInstallWebDialog extends LitElement {
         return;
       }
 
-      this._platform = chipFamilyToPlatform[esploader.chip.CHIP_NAME];
+      this._platform =
+        chipFamilyToPlatform[esploader.chip.CHIP_NAME as ChipFamily];
 
       const filesCallback =
         this.params.filesCallback ||
-        ((platform: ValueOf<typeof chipFamilyToPlatform>) =>
+        ((platform: SupportedPlatforms) =>
           this._getFilesForConfiguration(this.params.configuration!, platform));
 
       let files: FileToFlash[] | undefined = [];
@@ -261,7 +262,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
 
   private async _getFilesForConfiguration(
     configuration: string,
-    platform: ValueOf<typeof chipFamilyToPlatform>,
+    platform: SupportedPlatforms,
   ): Promise<FileToFlash[] | undefined> {
     let info: Configuration;
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -18,6 +18,7 @@ import {
   supportedPlatforms,
   PlatformData,
   chipFamilyToPlatform,
+  ChipFamily,
 } from "../const";
 import {
   compileConfiguration,
@@ -325,22 +326,20 @@ export class ESPHomeWizardDialog extends LitElement {
       </div>
 
       <mwc-list class="platforms">
-        ${Object.keys(supportedPlatforms).map((key) =>
-          supportedPlatforms[key as SupportedPlatforms].showInDeviceTypePicker
-            ? html`
-                <mwc-list-item
-                  hasMeta
-                  .platform=${key}
-                  @click=${this._handlePickPlatformClick}
-                >
-                  <span
-                    >${supportedPlatforms[key as SupportedPlatforms]
-                      .label}</span
+        ${(Object.keys(supportedPlatforms) as SupportedPlatforms[]).map(
+          (key) =>
+            supportedPlatforms[key].showInDeviceTypePicker
+              ? html`
+                  <mwc-list-item
+                    hasMeta
+                    .platform=${key}
+                    @click=${this._handlePickPlatformClick}
                   >
-                  ${metaChevronRight}
-                </mwc-list-item>
-              `
-            : html``,
+                    <span>${supportedPlatforms[key].label}</span>
+                    ${metaChevronRight}
+                  </mwc-list-item>
+                `
+              : html``,
         )}
       </mwc-list>
 
@@ -686,8 +685,8 @@ export class ESPHomeWizardDialog extends LitElement {
 
       let platform: SupportedPlatforms;
       const chipFamily = esploader.chip.CHIP_NAME;
-      if (Object.keys(chipFamilyToPlatform).includes(chipFamily)) {
-        platform = chipFamilyToPlatform[chipFamily];
+      if (chipFamily in chipFamilyToPlatform) {
+        platform = chipFamilyToPlatform[chipFamily as ChipFamily];
       } else {
         this._state = "connect_webserial";
         this._error = `Unable to identify the connected device (${esploader.chip.CHIP_NAME}).`;

--- a/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
+++ b/web.esphome.io/src/install-adoptable/install-adoptable-dialog.ts
@@ -2,6 +2,7 @@ import { LitElement, PropertyValues, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "@material/mwc-dialog";
 import "@material/mwc-button";
+import { supportedPlatforms, SupportedPlatforms } from "../../../src/const";
 import {
   openInstallWebDialog,
   preloadInstallWebDialog,
@@ -9,13 +10,9 @@ import {
 import { FileToFlash } from "../../../src/web-serial/flash";
 import { esphomeDialogStyles } from "../../../src/styles";
 
-const SUPPORTED_PLATFORMS = [
-  "ESP8266",
-  "ESP32",
-  "ESP32S2",
-  "ESP32S3",
-  "ESP32C3",
-];
+const SUPPORTED_PLATFORMS = Object.keys(
+  supportedPlatforms,
+) as SupportedPlatforms[];
 
 @customElement("esphome-install-adoptable-dialog")
 class ESPHomeInstallAdoptableDialog extends LitElement {
@@ -69,7 +66,9 @@ class ESPHomeInstallAdoptableDialog extends LitElement {
     openInstallWebDialog(
       {
         port: this.port,
-        async filesCallback(platform: string): Promise<FileToFlash[]> {
+        async filesCallback(
+          platform: SupportedPlatforms,
+        ): Promise<FileToFlash[]> {
           if (!SUPPORTED_PLATFORMS.includes(platform)) {
             throw new Error(
               `Unsupported platform ${platform}. Only ${SUPPORTED_PLATFORMS.join(


### PR DESCRIPTION
- make objects/arrays `as const` and use `satisfies` to keep exact value instead of generic string type
- simplify type usage