### PR TITLE
Fix ColoredConsole performance issues

### DIFF
--- a/src/util/console-color.ts
+++ b/src/util/console-color.ts
@@ -227,7 +227,6 @@ export const coloredConsoleStyles = `
     line-height: 1.45;
     border-radius: 3px;
     white-space: pre-wrap;
-    will-change: scroll-position;
     overflow-wrap: break-word;
     color: #ddd;
   }

--- a/src/util/console-color.ts
+++ b/src/util/console-color.ts
@@ -207,7 +207,7 @@ export class ColoredConsole {
   }
 
   addLine(line: string) {
-    // processing of lines is deferred for performance reasons
+    // Processing of lines is deferred for performance reasons
     if (this.state.lines.length == 0) {
       setTimeout(() => this.processLines(), 0);
     }

--- a/src/util/console-color.ts
+++ b/src/util/console-color.ts
@@ -6,6 +6,7 @@ interface ConsoleState {
   foregroundColor: string | null;
   backgroundColor: string | null;
   carriageReturn: boolean;
+  lines: string[];
   secret: boolean;
 }
 
@@ -18,6 +19,7 @@ export class ColoredConsole {
     foregroundColor: null,
     backgroundColor: null,
     carriageReturn: false,
+    lines: [],
     secret: false,
   };
 
@@ -27,25 +29,12 @@ export class ColoredConsole {
     return this.targetElement.innerText;
   }
 
-  addLine(line: string) {
+  processLine(line: string): Element {
     const re = /(?:\x1b|\\033)(?:\[(.*?)[@-~]|\].*?(?:\x07|\x07\\))/g;
     let i = 0;
 
-    if (this.state.carriageReturn) {
-      if (line !== "\n") {
-        // don't remove if \r\n
-        this.targetElement.removeChild(this.targetElement.lastChild!);
-      }
-      this.state.carriageReturn = false;
-    }
-
-    if (line.includes("\r")) {
-      this.state.carriageReturn = true;
-    }
-
     const lineSpan = document.createElement("span");
     lineSpan.classList.add("line");
-    this.targetElement.appendChild(lineSpan);
 
     const addSpan = (content: string) => {
       if (content === "") return;
@@ -178,16 +167,51 @@ export class ColoredConsole {
         }
       }
     }
+    addSpan(line.substring(i));
+    return lineSpan;
+  }
+
+  processLines() {
     const atBottom =
       this.targetElement.scrollTop >
       this.targetElement.scrollHeight - this.targetElement.offsetHeight - 50;
+    const prevCarriageReturn = this.state.carriageReturn;
+    const fragment = document.createDocumentFragment();
 
-    addSpan(line.substring(i));
+    if (this.state.lines.length == 0) {
+      return;
+    }
+
+    for (const line of this.state.lines) {
+      if (this.state.carriageReturn && line !== "\n") {
+        if (fragment.childElementCount) {
+          fragment.removeChild(fragment.lastChild!);
+        }
+      }
+      fragment.appendChild(this.processLine(line));
+      this.state.carriageReturn = line.includes("\r");
+    }
+
+    if (prevCarriageReturn && this.state.lines[0] !== "\n") {
+      this.targetElement.replaceChild(fragment, this.targetElement.lastChild!);
+    } else {
+      this.targetElement.appendChild(fragment);
+    }
+
+    this.state.lines = [];
 
     // Keep scroll at bottom
     if (atBottom) {
       this.targetElement.scrollTop = this.targetElement.scrollHeight;
     }
+  }
+
+  addLine(line: string) {
+    // processing of lines is deferred for performance reasons
+    if (this.state.lines.length == 0) {
+      setTimeout(() => this.processLines(), 0);
+    }
+    this.state.lines.push(line);
   }
 }
 
@@ -203,6 +227,7 @@ export const coloredConsoleStyles = `
     line-height: 1.45;
     border-radius: 3px;
     white-space: pre-wrap;
+    will-change: scroll-position;
     overflow-wrap: break-word;
     color: #ddd;
   }


### PR DESCRIPTION
When doing `update all` the logs can eventually get minutes behind and logging can even stop before the final summary. In addition to `update all` being unusable `web.esphome.io` would crash with a high volume of logs. 

The old code was adding an empty span to the live page. That span was then updated multiple times causing the browser to constantly re-render. Significant savings came from building the full span first and only adding the line after the span was complete. 

Adding lines and updating the scroll position can take a long time. Instead of adding each line immediately, lines are now buffered. Processing is deferred until the current call stack is complete. This way if multiple lines are received at the same time those lines will be added together in one call saving a lot of time. 

Before this change (`update all` with three devices):
  - time spent in addLine: 157.656 secs
  - total logging time: 194.428 secs

After this change (`update all` with three devices):
  - time spent in processLines: 24.794 secs
  - total logging time: 97.277 secs
  
Testing was done using IDF, which has tons of files and on a fast build machine. Instead of being almost two minutes behind the logs now keep up with the build. 

Validating the config was also an interesting test. Before these changes it took almost 10 seconds to log the full config. After this change the full config is logged instantly.  

The dashboard log viewer and `web.esphome.io` can handle a significantly higher volume of logs now. The dashboard can now keep up with putty even after 100k lines of scroll back. Instead of crashing the web browser like it previously did `web.esphome.io` can now handle high volumes of logging with web serial. Previously the code was stuck reading serial + adding lines, the call stack never returned as logging was so slow that serial data backed up looping forever. Now all serial date is buffered, the call stack returns and only then are the new lines rendered. 