### PR TITLE
Fix web.esphome.io logging

### DIFF
--- a/src/util/line-break-transformer.ts
+++ b/src/util/line-break-transformer.ts
@@ -8,7 +8,7 @@ export class LineBreakTransformer implements Transformer<string, string> {
     // Append new chunks to existing chunks.
     this.chunks += chunk;
     // For each line breaks in chunks, send the parsed lines out.
-    const lines = this.chunks.split("\r\n");
+    const lines = this.chunks.split(/\r?\n/);
     this.chunks = lines.pop()!;
     lines.forEach((line) => controller.enqueue(line + "\r\n"));
   }


### PR DESCRIPTION
Some of my devices are just sending \n and not \r\n which is causing all the logging to get stuck. Logs only appear all at once when you hit reset. Look for both possibilities instead of just \r\n.