### PR TITLE
Increase serial buffer size

### DIFF
--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -252,6 +252,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
           await sleep(1000);
           await this.params.port.open({
             baudRate: esploader.transport.baudrate,
+            bufferSize: 8192,
           });
         }
       } catch (err) {

--- a/src/logs-target/logs-target-dialog.ts
+++ b/src/logs-target/logs-target-dialog.ts
@@ -186,7 +186,7 @@ class ESPHomeLogsTargetDialog extends LitElement {
 
     try {
       const port = await navigator.serial.requestPort();
-      await port.open({ baudRate: 115200 });
+      await port.open({ baudRate: 115200, bufferSize: 8192 });
       this.shadowRoot!.querySelector("mwc-dialog")!.close();
       openLogsWebSerialDialog(port, true, this.configuration);
     } catch (err) {

--- a/web.esphome.io/src/dashboard/esp-connect-card.ts
+++ b/web.esphome.io/src/dashboard/esp-connect-card.ts
@@ -61,7 +61,7 @@ class EWESPConnectCard extends LitElement {
     }
 
     try {
-      await port.open({ baudRate: 115200 });
+      await port.open({ baudRate: 115200, bufferSize: 8192 });
     } catch (err: any) {
       alert(err.message);
       return;

--- a/web.esphome.io/src/dashboard/pico-connect-card.ts
+++ b/web.esphome.io/src/dashboard/pico-connect-card.ts
@@ -68,7 +68,7 @@ class EWPicoConnectCard extends LitElement {
     }
 
     try {
-      await port.open({ baudRate: 115200 });
+      await port.open({ baudRate: 115200, bufferSize: 8192 });
     } catch (err: any) {
       alert(err.message);
       return;

--- a/web.esphome.io/src/install-pico/install-pico-dialog.ts
+++ b/web.esphome.io/src/install-pico/install-pico-dialog.ts
@@ -98,7 +98,7 @@ class ESPHomeInstallPicoDialog extends LitElement {
     }
 
     try {
-      await port.open({ baudRate: 115200 });
+      await port.open({ baudRate: 115200, bufferSize: 8192 });
     } catch (err: any) {
       alert(err.message);
       return;


### PR DESCRIPTION
The default serial buffer size is 255 bytes which is only ~22 ms of logging data. With a decent amount of scroll back or some random delay data can get dropped. 

Increase this to a more reasonable amount for something like a browser, 8192 bytes is ~0.7 s of buffering. 