### PR TITLE
Add upload and empty config to the new device wizard

### DIFF
--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -1,13 +1,21 @@
 import { APIError, fetchApiJson, fetchApiText, streamLogs } from ".";
 import { SupportedPlatforms } from "../const";
 
+export interface CreateEmptyConfigParams {
+  type: "empty";
+  name: string;
+}
+
 export interface CreateBasicConfigParams {
+  type: "basic";
   name: string;
   ssid: string;
   psk: string;
   board: string;
   platform: SupportedPlatforms;
 }
+
+export type CreateConfigParams = CreateEmptyConfigParams | CreateBasicConfigParams;
 
 export interface Configuration {
   storage_version: number;
@@ -24,7 +32,7 @@ export interface Configuration {
   loaded_integrations: string[];
 }
 
-export const createConfiguration = (params: CreateBasicConfigParams) =>
+export const createConfiguration = (params: CreateConfigParams) =>
   fetchApiJson<{ configuration: string }>("./wizard", {
     method: "post",
     body: JSON.stringify(params),

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -21,7 +21,10 @@ export interface CreateBasicConfigParams {
   platform: SupportedPlatforms;
 }
 
-export type CreateConfigParams = CreateEmptyConfigParams | CreateUploadConfigParams | CreateBasicConfigParams;
+export type CreateConfigParams =
+  | CreateEmptyConfigParams
+  | CreateUploadConfigParams
+  | CreateBasicConfigParams;
 
 export interface Configuration {
   storage_version: number;

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -6,6 +6,12 @@ export interface CreateEmptyConfigParams {
   name: string;
 }
 
+export interface CreateUploadConfigParams {
+  type: "upload";
+  name: string;
+  file_content: string;
+}
+
 export interface CreateBasicConfigParams {
   type: "basic";
   name: string;
@@ -15,7 +21,7 @@ export interface CreateBasicConfigParams {
   platform: SupportedPlatforms;
 }
 
-export type CreateConfigParams = CreateEmptyConfigParams | CreateBasicConfigParams;
+export type CreateConfigParams = CreateEmptyConfigParams | CreateUploadConfigParams | CreateBasicConfigParams;
 
 export interface Configuration {
   storage_version: number;

--- a/src/api/configuration.ts
+++ b/src/api/configuration.ts
@@ -1,7 +1,7 @@
 import { APIError, fetchApiJson, fetchApiText, streamLogs } from ".";
 import { SupportedPlatforms } from "../const";
 
-export interface CreateConfigParams {
+export interface CreateBasicConfigParams {
   name: string;
   ssid: string;
   psk: string;
@@ -24,7 +24,7 @@ export interface Configuration {
   loaded_integrations: string[];
 }
 
-export const createConfiguration = (params: CreateConfigParams) =>
+export const createConfiguration = (params: CreateBasicConfigParams) =>
   fetchApiJson<{ configuration: string }>("./wizard", {
     method: "post",
     body: JSON.stringify(params),

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -710,6 +710,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
   private async _handlePickBoardSubmit() {
     if (!this._board) return;
+    if(this._data.type !== "basic") return;
     this._data.board = this._board!;
 
     this._busy = true;
@@ -742,6 +743,7 @@ export class ESPHomeWizardDialog extends LitElement {
     this._error = undefined;
     let esploader: ESPLoader | undefined;
     let removeConfig = false;
+    if(this._data.type !== "basic") return;
     try {
       let port: SerialPort | undefined;
 

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -280,6 +280,7 @@ export class ESPHomeWizardDialog extends LitElement {
     const heading = "Create configuration";
     let hideActions = true;
     const content = html`
+      ${this._error ? html`<div class="error">${this._error}</div>` : ""}
       <div
         @dragover=${(ev: DragEvent) => {
           ev.preventDefault();
@@ -772,15 +773,21 @@ export class ESPHomeWizardDialog extends LitElement {
   private async _handleConfigFileUpload() {
     const input = this._configFileInput;
     const file = input.files?.[0];
-    const response = await createConfiguration({
-      type: "upload",
-      name: file?.name.replace(/\.ya?ml$/, ""),
-      file_content: this._encodeToBase64(file ? await file.text() : ""),
-    } as CreateUploadConfigParams);
-    this._configFilename = response.configuration;
-    refreshDevices();
-    this._state = "done";
-    this._busy = false;
+    try {
+      const response = await createConfiguration({
+        type: "upload",
+        name: file?.name.replace(/\.ya?ml$/, ""),
+        file_content: this._encodeToBase64(file ? await file.text() : ""),
+      } as CreateUploadConfigParams);
+      this._configFilename = response.configuration;
+      refreshDevices();
+      this._state = "done";
+    } catch (err: any) {
+      console.error("err was", err.message);
+      this._error = err.message || err;
+    } finally {
+      this._busy = false;
+    }
   }
 
   private _handleUseRecommendedCheckbox(ev: Event) {

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -47,6 +47,7 @@ import { copyToClipboard } from "../util/copy-clipboard";
 import { sleep } from "../util/sleep";
 import { createESPLoader } from "../web-serial/create-esploader";
 import { resetSerialDevice } from "../web-serial/reset-serial-device";
+import { classMap } from "lit/directives/class-map.js";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
@@ -108,6 +109,8 @@ export class ESPHomeWizardDialog extends LitElement {
   @query(".api-key-banner") private _inputApiKeyBanner?: TextField;
   @query("mwc-dialog") private _dialog!: HTMLDialogElement;
 
+  @state()
+  private _isDraggingOverConfigUpload = false;
   @query("#config-file-input") private _configFileInput!: HTMLInputElement;
 
   private _platformData(): PlatformData {
@@ -268,7 +271,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
     return [heading, content, hideActions];
   }
-  
+
   private _renderPickNewConfigType(): [string | undefined, TemplateResult, boolean] {
     const heading = "Create configuration";
     let hideActions = true;
@@ -276,12 +279,15 @@ export class ESPHomeWizardDialog extends LitElement {
       <div
         @dragover=${(ev: DragEvent) => {
           ev.preventDefault();
+          this._isDraggingOverConfigUpload = true;
         }}
         @dragleave=${(ev: DragEvent) => {
           ev.preventDefault();
+          this._isDraggingOverConfigUpload = false;
         }}
         @drop=${(ev: DragEvent) => {
           ev.preventDefault();
+          this._isDraggingOverConfigUpload = false;
 
           const file = ev.dataTransfer?.files?.[0];
           if (file) {
@@ -293,6 +299,9 @@ export class ESPHomeWizardDialog extends LitElement {
             this._handleConfigFileUpload();
           }
         }}
+        class="${classMap({
+          ["dragging-over"]: this._isDraggingOverConfigUpload,
+        })}"
       >
         <input
           type="file"
@@ -984,6 +993,10 @@ export class ESPHomeWizardDialog extends LitElement {
         left: 0;
         bottom: 4px;
         z-index: 1;
+      }
+      .dragging-over {
+        outline: 2px dashed var(--mdc-theme-primary);
+        background-color: rgba(0, 0, 0, 0.05);
       }
     `,
   ];

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -793,7 +793,7 @@ export class ESPHomeWizardDialog extends LitElement {
     esphomeSvgStyles,
     css`
       :host {
-        --mdc-dialog-max-width: 390px;
+        --mdc-dialog-max-width: 490px;
       }
       .center {
         text-align: center;

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -106,6 +106,7 @@ export class ESPHomeWizardDialog extends LitElement {
   @query("mwc-textfield[name=ssid]") private _inputSSID!: TextField;
   @query("mwc-textfield[name=password]") private _inputPassword!: TextField;
   @query(".api-key-banner") private _inputApiKeyBanner?: TextField;
+  @query("mwc-dialog") private _dialog!: HTMLDialogElement;
 
   @query("#config-file-input") private _configFileInput!: HTMLInputElement;
 
@@ -717,7 +718,7 @@ export class ESPHomeWizardDialog extends LitElement {
       );
       this._configFilename = response.configuration;
       refreshDevices();
-      this._state = "done";
+      this._dialog.close();
     } catch (err: any) {
       this._error = err.message || err;
     } finally {

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -272,13 +272,33 @@ export class ESPHomeWizardDialog extends LitElement {
     const heading = "Create configuration";
     let hideActions = true;
     const content = html`
-      <div>
+      <div
+        @dragover=${(ev: DragEvent) => {
+          ev.preventDefault();
+        }}
+        @dragleave=${(ev: DragEvent) => {
+          ev.preventDefault();
+        }}
+        @drop=${(ev: DragEvent) => {
+          ev.preventDefault();
+
+          const file = ev.dataTransfer?.files?.[0];
+          if (file) {
+            if (!file.name.endsWith(".yaml") && !file.name.endsWith(".yml")) {
+              console.error("Invalid file type. Please provide a .yaml or .yml file.");
+              return;
+            }
+            this._configFileInput.files = ev.dataTransfer.files;
+            this._handleConfigFileUpload();
+          }
+        }}
+      >
         <input
           type="file"
           accept=".yaml,.yml"
           style="display: none;"
           id="config-file-input"
-          @change=${this._handleConfigFileChange}
+          @change=${this._handleConfigFileUpload}
         />
         <p>How would you like to create your configuration?</p>
         <mwc-list>
@@ -304,6 +324,7 @@ export class ESPHomeWizardDialog extends LitElement {
             ${metaChevronRight}
           </mwc-list-item>
         </mwc-list>
+        <small>You can also drag and drop your .yaml file here</small>
       </div>
     `;
 
@@ -703,9 +724,9 @@ export class ESPHomeWizardDialog extends LitElement {
       this._busy = false;
     }
   }
-  
-  private async _handleConfigFileChange(ev: Event) {
-    const input = ev.target as HTMLInputElement;
+
+  private async _handleConfigFileUpload() {
+    const input = this._configFileInput;
     const file = input.files?.[0];
     const response = await createConfiguration({
       type: "upload",

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -735,13 +735,25 @@ export class ESPHomeWizardDialog extends LitElement {
     }
   }
 
+  private _encodeToBase64(str: string): string {
+    const utf8Encoder = new TextEncoder();
+    const utf8Bytes = utf8Encoder.encode(str);
+
+    let binaryString = '';
+    for (let i = 0; i < utf8Bytes.length; i++) {
+      binaryString += String.fromCharCode(utf8Bytes[i]);
+    }
+
+    return btoa(binaryString);
+  }
+
   private async _handleConfigFileUpload() {
     const input = this._configFileInput;
     const file = input.files?.[0];
     const response = await createConfiguration({
       type: "upload",
       name: file?.name.replace(/\.ya?ml$/, ""),
-      file_content: btoa(file ? await file.text() : ""),
+      file_content: this._encodeToBase64(file ? await file.text() : ""),
     } as CreateUploadConfigParams)
     this._configFilename = response.configuration;
     refreshDevices();

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -22,7 +22,7 @@ import {
 } from "../const";
 import {
   compileConfiguration,
-  CreateConfigParams,
+  CreateBasicConfigParams,
   createConfiguration,
   deleteConfiguration,
   getConfigurationApiKey,
@@ -66,7 +66,7 @@ export class ESPHomeWizardDialog extends LitElement {
   // undefined = not loaded
   @state() private _hasWifiSecrets: undefined | boolean = undefined;
 
-  private _data: Partial<CreateConfigParams> = {
+  private _data: Partial<CreateBasicConfigParams> = {
     ssid: `!secret ${SECRET_WIFI_SSID}`,
     psk: `!secret ${SECRET_WIFI_PASSWORD}`,
   };
@@ -628,7 +628,7 @@ export class ESPHomeWizardDialog extends LitElement {
         await storeWifiSecrets(this._wifi.ssid, this._wifi.password);
       }
       const response = await createConfiguration(
-        this._data as CreateConfigParams,
+        this._data as CreateBasicConfigParams,
       );
       this._configFilename = response.configuration;
       refreshDevices();
@@ -696,7 +696,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
       try {
         const { configuration } = await createConfiguration(
-          this._data as CreateConfigParams,
+          this._data as CreateBasicConfigParams,
         );
         this._configFilename = configuration;
       } catch (err) {

--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -272,7 +272,11 @@ export class ESPHomeWizardDialog extends LitElement {
     return [heading, content, hideActions];
   }
 
-  private _renderPickNewConfigType(): [string | undefined, TemplateResult, boolean] {
+  private _renderPickNewConfigType(): [
+    string | undefined,
+    TemplateResult,
+    boolean,
+  ] {
     const heading = "Create configuration";
     let hideActions = true;
     const content = html`
@@ -292,7 +296,9 @@ export class ESPHomeWizardDialog extends LitElement {
           const file = ev.dataTransfer?.files?.[0];
           if (file) {
             if (!file.name.endsWith(".yaml") && !file.name.endsWith(".yml")) {
-              console.error("Invalid file type. Please provide a .yaml or .yml file.");
+              console.error(
+                "Invalid file type. Please provide a .yaml or .yml file.",
+              );
               return;
             }
             this._configFileInput.files = ev.dataTransfer.files;
@@ -312,25 +318,41 @@ export class ESPHomeWizardDialog extends LitElement {
         />
         <p>How would you like to create your configuration?</p>
         <mwc-list>
-          <mwc-list-item twoline hasMeta @click=${() => {
-            this._state = "basic_config";
-          }}>
+          <mwc-list-item
+            twoline
+            hasMeta
+            @click=${() => {
+              this._state = "basic_config";
+            }}
+          >
             <span>New Device Setup</span>
             <span slot="secondary">A guided process to get you started.</span>
             ${metaChevronRight}
           </mwc-list-item>
-          <mwc-list-item twoline hasMeta @click=${() => {
-            this._configFileInput.click();
-          }}>
+          <mwc-list-item
+            twoline
+            hasMeta
+            @click=${() => {
+              this._configFileInput.click();
+            }}
+          >
             <span>Import from File</span>
-            <span slot="secondary">Use an existing ESPHome configuration (.yaml).</span>
+            <span slot="secondary"
+              >Use an existing ESPHome configuration (.yaml).</span
+            >
             ${metaChevronRight}
           </mwc-list-item>
-          <mwc-list-item twoline hasMeta @click=${() => {
-            this._state = "empty_config";
-          }}>
+          <mwc-list-item
+            twoline
+            hasMeta
+            @click=${() => {
+              this._state = "empty_config";
+            }}
+          >
             <span>Empty Configuration</span>
-            <span slot="secondary">For manually writing or pasting a configuration.</span>
+            <span slot="secondary"
+              >For manually writing or pasting a configuration.</span
+            >
             ${metaChevronRight}
           </mwc-list-item>
         </mwc-list>
@@ -739,7 +761,7 @@ export class ESPHomeWizardDialog extends LitElement {
     const utf8Encoder = new TextEncoder();
     const utf8Bytes = utf8Encoder.encode(str);
 
-    let binaryString = '';
+    let binaryString = "";
     for (let i = 0; i < utf8Bytes.length; i++) {
       binaryString += String.fromCharCode(utf8Bytes[i]);
     }
@@ -754,7 +776,7 @@ export class ESPHomeWizardDialog extends LitElement {
       type: "upload",
       name: file?.name.replace(/\.ya?ml$/, ""),
       file_content: this._encodeToBase64(file ? await file.text() : ""),
-    } as CreateUploadConfigParams)
+    } as CreateUploadConfigParams);
     this._configFilename = response.configuration;
     refreshDevices();
     this._state = "done";
@@ -783,7 +805,7 @@ export class ESPHomeWizardDialog extends LitElement {
 
   private async _handlePickBoardSubmit() {
     if (!this._board) return;
-    if(this._data.type !== "basic") return;
+    if (this._data.type !== "basic") return;
     this._data.board = this._board!;
 
     this._busy = true;
@@ -816,7 +838,7 @@ export class ESPHomeWizardDialog extends LitElement {
     this._error = undefined;
     let esploader: ESPLoader | undefined;
     let removeConfig = false;
-    if(this._data.type !== "basic") return;
+    if (this._data.type !== "basic") return;
     try {
       let port: SerialPort | undefined;
 


### PR DESCRIPTION
Implements https://github.com/esphome/backlog/issues/7

Depends on https://github.com/esphome/esphome/pull/10203

# Overview

This PR add another step to the new device wizard where the user can now select how the configuration should be created:
- New Device Setup: continues the wizard as before
- Import from file: asks the user to upload an existing .yaml configuration file
- Empty configuration: creates a empty .yaml file for manual writing or pasting from https://devices.esphome.io/

Dropping a yaml file over this dialog is also supported.

# Screenshot

<img width="855" height="746" alt="image" src="https://github.com/user-attachments/assets/622a3517-0f51-4eb6-a0f9-eebfcfd07ea2" />
