### PR TITLE
Fix tsc error with TextDecoderStream

### DIFF
--- a/src/logs-webserial/ewt-console.ts
+++ b/src/logs-webserial/ewt-console.ts
@@ -93,9 +93,12 @@ export class EwtConsole extends HTMLElement {
     this.logger.debug("Starting console read loop");
     try {
       await this.port
-        .readable!.pipeThrough(new TextDecoderStream() as ReadableWritablePair<string, Uint8Array>, {
-          signal: abortSignal,
-        })
+        .readable!.pipeThrough(
+          new TextDecoderStream() as ReadableWritablePair<string, Uint8Array>,
+          {
+            signal: abortSignal,
+          },
+        )
         .pipeThrough(new TransformStream(new LineBreakTransformer()))
         .pipeThrough(new TransformStream(new ESPHomeLogTransformer()))
         .pipeThrough(new TransformStream(new TimestampTransformer()))


### PR DESCRIPTION
```
Error: src/logs-webserial/ewt-console.ts(96,32): error TS2345: Argument of type 'TextDecoderStream' is not assignable to parameter of type 'ReadableWritablePair<string, Uint8Array<ArrayBufferLike>>'.
  Types of property 'writable' are incompatible.
    Type 'WritableStream<BufferSource>' is not assignable to type 'WritableStream<Uint8Array<ArrayBufferLike>>'.
      Type 'BufferSource' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
        Type 'ArrayBuffer' is missing the following properties from type 'Uint8Array<ArrayBufferLike>': BYTES_PER_ELEMENT, buffer, byteOffset, copyWithin, and 24 more.
Error: Process completed with exit code 2.
```