### PR TITLE
Print json encoded error details if available

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,7 +28,20 @@ const fetchApiBase = async (
   }
   const resp = await fetch(path, options);
   if (!resp.ok) {
-    throw new APIError(`Request not successful (${resp.status})`, resp.status);
+    let errMessage = `Request not successful (${resp.status})`;
+    try {
+      const contentType = resp.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        const json = await resp.json();
+        errMessage += `: ${json.error}`;
+      } else {
+        const text = await resp.text();
+        if (text) errMessage += `: ${text}`;
+      }
+    } catch {
+      // Ignore parsing errors, use generic message
+    }
+    throw new APIError(errMessage, resp.status);
   }
   return resp;
 };


### PR DESCRIPTION
The web server already sent specific error messages, but those were never parsed and therefore never shown to the user.
This PR adds the error message to the `APIError` exception if available, giving the user more context about what went wrong.

# Screenshot
<img width="731" height="642" alt="Screenshot From 2025-08-28 11-44-01" src="https://github.com/user-attachments/assets/eef71f8a-d7f1-4bf4-af74-58eaa852f47f" />
