### PR TITLE
Fix WebSocket disconnection and data loss when opening editor

### DIFF
--- a/src/util/websocket-collection.ts
+++ b/src/util/websocket-collection.ts
@@ -54,19 +54,9 @@ export const createWebSocketCollection = <T>(events: {
       return () => {
         subscribers.delete(onChange);
 
-        // Cleanup when no subscribers left
-        if (subscribers.size === 0 && isConnected) {
-          // Clean up all WebSocket event listeners
-          unsubscribers.forEach((unsub) => unsub());
-          unsubscribers.length = 0;
-
-          // Clear cached data
-          data = undefined;
-
-          // Disconnect WebSocket
-          dashboardWebSocket.disconnect();
-          isConnected = false;
-        }
+        // Don't disconnect WebSocket or clear data when no subscribers left
+        // This prevents connection loss and data loss when components unmount (e.g., when opening editor)
+        // The WebSocket connection will remain active to receive updates
       };
     },
 


### PR DESCRIPTION
## Summary

Fixes an issue where opening the editor caused the dashboard WebSocket to disconnect and lose all device data, resulting in "Connection lost/restored" messages and empty device cards after closing the editor.

## Problem

When opening the file editor:
1. The devices list component was removed from DOM
2. This triggered `disconnectedCallback`, unsubscribing from WebSocket collection
3. WebSocket collection detected zero subscribers and automatically:
   - Disconnected the WebSocket (showing "Connection lost")
   - Cleared all cached data
4. When closing the editor, devices reconnected but data was gone
5. Cards remained empty permanently (initial_state is only sent on first connection, not on reconnection)

## Solution

The WebSocket collection was too aggressive in trying to clean up resources. It disconnected and cleared data whenever the subscriber count reached zero, even though the dashboard page was still active and would need the connection again immediately. This issue may not have been caught during initial testing due to browser caching or timing variations in component lifecycle events.

Modified `src/util/websocket-collection.ts` to keep the WebSocket connection alive and preserve cached data for the lifetime of the dashboard page, regardless of component mount/unmount cycles. This ensures:
- No connection lost/restored messages when opening/closing editor
- Device cards reappear immediately after closing editor
- Real-time updates continue in background while editing

## Changes

- **src/util/websocket-collection.ts**: Removed automatic disconnect/cleanup logic when subscriber count reaches zero

## Testing

1. Open dashboard with devices
2. Click "Edit" on any device
3. Verify no "Connection lost" message appears
4. Close editor
5. Verify all device cards appear immediately without "Connection restored" message
