### PR TITLE
Fix VISIT button showing for devices without web_server configured

### DIFF
--- a/src/devices/configured-device-card.ts
+++ b/src/devices/configured-device-card.ts
@@ -117,7 +117,7 @@ class ESPHomeConfiguredDeviceCard extends LitElement {
                 </div>
               `
             : ""}
-          ${this.device.loaded_integrations?.includes("web_server")
+          ${this.device.web_port != null
             ? html`
                 <a
                   href=${`http://${this.device.address}${


### PR DESCRIPTION
## Summary

Fixes an issue where the VISIT button incorrectly appears for devices that don't have the `web_server` component configured, due to `loaded_integrations` including `web_server` when components like `captive_portal` are enabled.

## Problem

When a device configuration includes `captive_portal`:
1. The captive portal component auto-loads the `ota.web_server` platform for its OTA functionality
2. ESPHome's `loaded_integrations` in the storage JSON includes `web_server` even though the user never explicitly configured it
3. The dashboard was checking `loaded_integrations` to determine whether to show the VISIT button
4. Result: VISIT button appears but leads to a non-functional web server (404 error)

This affects all devices compiled with ESPHome 2025.7+ that have `captive_portal` enabled but no explicit `web_server` configuration.

## Solution

Changed the VISIT button visibility logic to check the `web_port` field instead of the `loaded_integrations` array.

The `web_port` property in ESPHome core (`esphome/core/__init__.py:652-662`) checks `CONF_WEB_SERVER in self.config` rather than relying on integration loading state. This is the source of truth for explicit user configuration:
- `web_port: 80` (or other port number) = web server is explicitly configured by user
- `web_port: null` = no web server configured (even if `web_server` appears in `loaded_integrations`)

This provides a reliable indicator of whether the device has an accessible web interface.

Unit tests were added in esphome/esphome#11811 to prevent regression of the `web_port` property behavior.

## Changes

- **src/devices/configured-device-card.ts:120**: Changed condition from `this.device.loaded_integrations?.includes("web_server")` to `this.device.web_port != null`
