### PR TITLE
Improve message stating incompatibility with the current browser

### DIFF
--- a/src/wizard/wizard-dialog.ts
+++ b/src/wizard/wizard-dialog.ts
@@ -233,9 +233,9 @@ export class ESPHomeWizardDialog extends LitElement {
         wirelessly.
       </div>
       <div>
-        The following issues prevent ESPHome from being able to remotely install
-        the necessary firmware on devices physically connected to the client
-        computer (running the browser):
+        The following issues prevent ESPHome from being able to install the
+        firmware on devices physically connected to the client computer (running
+        the browser):
         <ul>
           <li>Your browser does not support WebSerial.</li>
           ${allowsWebSerial


### PR DESCRIPTION
I'm new to esphome project and when I first saw the message talking about the incompatibility regarding setting up the device, I was utterly confused. After googling I found the https://github.com/esphome/feature-requests/issues/2913 issue which perfectly describes my confusion.

Based on suggested improvements posted in the issue, I've came up with a slightly modified version to hopefully improve the situation.

| Old message  | New message |
| ------------- | ------------- |
| A device needs to be connected to a computer using a USB cable to be added to ESPHome. Once added, ESPHome will interact with the device wirelessly.<br><br>You are not browsing the ESPHome Device Builder over a secure connection (HTTPS).This prevents ESPHome from being able to install this on devices connected to this computer.<br><br>You will still be able to install ESPHome by connecting the device to the computer that runs the ESPHome Device Builder.<br><br>Alternatively, you can use ESPHome Web to prepare a device for being used with ESPHome using this computer. | A device needs to be connected to a computer (either the server running ESPHome or the client running the browser) using a USB cable to be added to ESPHome. Once added, ESPHome will interact with the device wirelessly.<br><br>The following issues prevent ESPHome from being able to remotely install the necessary firmware on devices physically connected to the client computer (running the browser):<br><br> - Your browser does not support WebSerial.<br> - You are not browsing the ESPHome Device Builder over a secure connection (HTTPS).<br><br>You will still be able to install ESPHome by connecting the device to the computer or server that is hosting the ESPHome dashboard.<br><br>Alternatively, you can use ESPHome Web (an external service provided by the ESPHome project) to prepare your device for being used with ESPHome using this computer and browser (if compatible; see above).

(note the messages differ slightly based on whether running in secure context)

Fixes https://github.com/esphome/feature-requests/issues/2913