### PR TITLE
[Dashboard] Add online/offline status filter for devices

### DIFF
--- a/src/devices/devices-list.ts
+++ b/src/devices/devices-list.ts
@@ -114,12 +114,16 @@ class ESPHomeDevicesList extends LitElement {
           @click=${() => this._handleStatusFilterChange("all")}
         ></mwc-button>
         <mwc-button
-          class="filter-button ${this._statusFilter === "online" ? "active" : ""}"
+          class="filter-button ${this._statusFilter === "online"
+            ? "active"
+            : ""}"
           label="Online"
           @click=${() => this._handleStatusFilterChange("online")}
         ></mwc-button>
         <mwc-button
-          class="filter-button ${this._statusFilter === "offline" ? "active" : ""}"
+          class="filter-button ${this._statusFilter === "offline"
+            ? "active"
+            : ""}"
           label="Offline"
           @click=${() => this._handleStatusFilterChange("offline")}
         ></mwc-button>
@@ -305,7 +309,11 @@ class ESPHomeDevicesList extends LitElement {
     // Load saved filter from localStorage
     try {
       const savedFilter = localStorage.getItem("esphome-status-filter");
-      if (savedFilter === "online" || savedFilter === "offline" || savedFilter === "all") {
+      if (
+        savedFilter === "online" ||
+        savedFilter === "offline" ||
+        savedFilter === "all"
+      ) {
         this._statusFilter = savedFilter;
       }
     } catch (e) {


### PR DESCRIPTION
## Description

This PR adds a status filter to the ESPHome Dashboard device list, allowing users to filter devices by their online/offline status.

### Changes Made

- Added three filter buttons to the device list: "All", "Online", and "Offline"
- Filter buttons appear between the search bar and the device grid
- Filter applies only to configured devices (importable/discovered devices are not affected)
- Active filter button is visually highlighted with the primary theme color
- Filter selection persists across page reloads using localStorage

### Implementation Details

- Added `StatusFilter` type: `"all" | "online" | "offline"`
- New `_statusFilter` state property to track the current filter selection
- Enhanced `_filter()` method to check device online status from `_onlineStatus`
- Filter state is saved to localStorage as `esphome-status-filter`
- On component initialization, the saved filter is restored from localStorage

### Use Case

Users with many ESPHome devices can now quickly:
- View only online devices to check active devices
- View only offline devices to identify devices that need attention
- Toggle between views without losing their search query

### Testing

- Built successfully with `script/build`
- Filter UI renders correctly above device grid
- Filter logic correctly shows/hides devices based on online status
- Filter selection persists after page reload
- Works alongside existing search functionality