### PR TITLE
Clarify data privacy message on EW dashboard

### DIFF
--- a/web.esphome.io/src/dashboard/ew-dashboard.ts
+++ b/web.esphome.io/src/dashboard/ew-dashboard.ts
@@ -40,7 +40,7 @@ class EWDashboard extends LitElement {
             </p>
             <p>
               ESPHome Web runs 100% in your browser. No data will leave your
-              computer.
+              network.
             </p>
             <p>
               This page is a lite variant of ESPHome. If you want to create and


### PR DESCRIPTION
ESPHome Web *does* by its very purpose send data off your computer (to the ESP device). Update message accordingly to be more accurate.

My change is not necessarily the best way to express this clearly, so please update the message further if desired.