### PR TITLE
feat: batch upgrade devices

### DIFF
--- a/src/devices/importable-device-card.ts
+++ b/src/devices/importable-device-card.ts
@@ -32,7 +32,8 @@ class ESPHomeImportableDeviceCard extends LitElement {
                 </div>
               `
             : ""}
-          ${this.device.project_name}
+          <div>${this.device.project_name}</div>
+          <div class="device-version">Firmware: ${this.device.project_version}</div>
         </div>
 
         <div class="card-actions">
@@ -99,6 +100,11 @@ class ESPHomeImportableDeviceCard extends LitElement {
         font-family:
           "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
           monospace;
+      }
+      .device-version {
+        font-size: 13px;
+        color: var(--secondary-text-color);
+        margin-top: 4px;
       }
       .card-actions mwc-button {
         --mdc-theme-primary: #4caf50;

--- a/src/esphome-main.ts
+++ b/src/esphome-main.ts
@@ -2,7 +2,7 @@ import "./devices/devices-list";
 import "./components/esphome-header-menu";
 import "./components/esphome-fab";
 import { LitElement, html, PropertyValues } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, state, query } from "lit/decorators.js";
 import { connectionStatus } from "./util/connection-status";
 
 @customElement("esphome-main")
@@ -16,6 +16,12 @@ class ESPHomeMainView extends LitElement {
   @state() private editing?: string;
 
   @state() private showDiscoveredDevices = false;
+
+  @state() private _selectedCount = 0;
+
+  @state() private _selectedConfigurations: string[] = [];
+
+  @query("esphome-devices-list") private _devicesList?: HTMLElement;
 
   protected render() {
     if (this.editing) {
@@ -40,7 +46,10 @@ class ESPHomeMainView extends LitElement {
         <esphome-header-menu
           .logoutUrl=${this.logoutUrl}
           .showDiscoveredDevices=${this.showDiscoveredDevices}
+          .selectedCount=${this._selectedCount}
+          .selectedConfigurations=${this._selectedConfigurations}
           @toggle-discovered-devices=${this._toggleDiscoveredDevices}
+          @update-selected-started=${this._clearSelection}
         ></esphome-header-menu>
       </header>
 
@@ -48,6 +57,7 @@ class ESPHomeMainView extends LitElement {
         <esphome-devices-list
           .showDiscoveredDevices=${this.showDiscoveredDevices}
           @toggle-discovered-devices=${this._toggleDiscoveredDevices}
+          @selection-changed=${this._handleSelectionChanged}
         ></esphome-devices-list>
       </main>
 
@@ -86,6 +96,21 @@ class ESPHomeMainView extends LitElement {
 
   private _toggleDiscoveredDevices() {
     this.showDiscoveredDevices = !this.showDiscoveredDevices;
+  }
+
+  private _handleSelectionChanged(
+    e: CustomEvent<{ count: number; configurations: string[] }>,
+  ) {
+    this._selectedCount = e.detail.count;
+    this._selectedConfigurations = e.detail.configurations;
+  }
+
+  private _clearSelection() {
+    this._selectedCount = 0;
+    this._selectedConfigurations = [];
+    if (this._devicesList) {
+      (this._devicesList as any).clearSelection();
+    }
   }
 }
 

--- a/src/update-selected/index.ts
+++ b/src/update-selected/index.ts
@@ -1,0 +1,8 @@
+const preload = () => import("./update-selected-dialog");
+
+export const openUpdateSelectedDialog = (configurations: string[]) => {
+  preload();
+  const dialog = document.createElement("esphome-update-selected-dialog");
+  (dialog as any).configurations = configurations;
+  document.body.append(dialog);
+};

--- a/src/update-selected/update-selected-dialog.ts
+++ b/src/update-selected/update-selected-dialog.ts
@@ -1,0 +1,292 @@
+import { LitElement, html, css, unsafeCSS } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import "@material/mwc-dialog";
+import "@material/mwc-button";
+import { StreamError, streamLogs } from "../api";
+import { ColoredConsole, coloredConsoleStyles } from "../util/console-color";
+import { fireEvent } from "../util/fire-event";
+import { esphomeDialogStyles } from "../styles";
+import { textDownload } from "../util/file-download";
+
+interface DeviceStatus {
+  configuration: string;
+  status: "pending" | "running" | "success" | "failed";
+}
+
+@customElement("esphome-update-selected-dialog")
+class ESPHomeUpdateSelectedDialog extends LitElement {
+  @property({ type: Array }) public configurations: string[] = [];
+
+  @state() private _deviceStatuses: DeviceStatus[] = [];
+  @state() private _currentIndex = 0;
+  @state() private _isRunning = true;
+
+  private _coloredConsole?: ColoredConsole;
+  private _abortController?: AbortController;
+
+  protected firstUpdated() {
+    this._deviceStatuses = this.configurations.map((config) => ({
+      configuration: config,
+      status: "pending",
+    }));
+
+    const logContainer = this.shadowRoot!.querySelector(".log-container")!;
+    this._coloredConsole = new ColoredConsole(logContainer as HTMLElement);
+
+    this._runNextUpdate();
+  }
+
+  protected render() {
+    const successCount = this._deviceStatuses.filter(
+      (d) => d.status === "success",
+    ).length;
+    const failedCount = this._deviceStatuses.filter(
+      (d) => d.status === "failed",
+    ).length;
+    const pendingCount = this._deviceStatuses.filter(
+      (d) => d.status === "pending",
+    ).length;
+
+    return html`
+      <mwc-dialog
+        open
+        heading="Install Selected (${this._currentIndex}/${this.configurations.length})"
+        scrimClickAction
+        @closed=${this._handleClose}
+      >
+        <div class="status-summary">
+          <span class="status-badge pending" title="Pending">${pendingCount} pending</span>
+          <span class="status-badge success" title="Success">${successCount} done</span>
+          <span class="status-badge failed" title="Failed">${failedCount} failed</span>
+        </div>
+
+        <div class="device-list">
+          ${this._deviceStatuses.map(
+            (device) => html`<span class="device ${device.status}">${device.configuration}</span>`,
+          )}
+        </div>
+
+        <div class="log-container log"></div>
+
+        <mwc-button
+          slot="secondaryAction"
+          label="Download Logs"
+          @click=${this._downloadLogs}
+        ></mwc-button>
+
+        <mwc-button
+          slot="primaryAction"
+          dialogAction="close"
+          .label=${this._isRunning ? "Stop" : "Close"}
+        ></mwc-button>
+      </mwc-dialog>
+    `;
+  }
+
+  private async _runNextUpdate() {
+    if (this._currentIndex >= this.configurations.length) {
+      this._isRunning = false;
+      fireEvent(this, "update-selected-done");
+      return;
+    }
+
+    const config = this.configurations[this._currentIndex];
+
+    // Update status to running
+    this._deviceStatuses = this._deviceStatuses.map((d, i) =>
+      i === this._currentIndex ? { ...d, status: "running" as const } : d,
+    );
+
+    this._coloredConsole?.addLine(
+      `\n\x1b[1;36m========== Installing ${config} (${this._currentIndex + 1}/${this.configurations.length}) ==========\x1b[0m\n`,
+    );
+
+    this._abortController = new AbortController();
+
+    try {
+      // First compile
+      this._coloredConsole?.addLine(`\x1b[1;33mCompiling...\x1b[0m\n`);
+      await streamLogs(
+        "compile",
+        { configuration: config },
+        (line) => {
+          this._coloredConsole?.addLine(line);
+        },
+        this._abortController,
+      );
+
+      // Then upload
+      this._coloredConsole?.addLine(`\x1b[1;33mUploading...\x1b[0m\n`);
+      await streamLogs(
+        "upload",
+        { configuration: config, port: "OTA" },
+        (line) => {
+          this._coloredConsole?.addLine(line);
+        },
+        this._abortController,
+      );
+
+      // Success
+      this._deviceStatuses = this._deviceStatuses.map((d, i) =>
+        i === this._currentIndex ? { ...d, status: "success" as const } : d,
+      );
+      this._coloredConsole?.addLine(
+        `\x1b[1;32m✓ ${config} installed successfully\x1b[0m\n`,
+      );
+    } catch (error) {
+      // Failed - continue to next device
+      this._deviceStatuses = this._deviceStatuses.map((d, i) =>
+        i === this._currentIndex ? { ...d, status: "failed" as const } : d,
+      );
+      const errorCode = error instanceof StreamError ? error.code : "unknown";
+      this._coloredConsole?.addLine(
+        `\x1b[1;31m✗ ${config} failed (exit code: ${errorCode})\x1b[0m\n`,
+      );
+    }
+
+    this._currentIndex++;
+    this.requestUpdate();
+
+    // Continue with next device
+    if (this._isRunning) {
+      this._runNextUpdate();
+    }
+  }
+
+  private _handleClose() {
+    if (this._abortController) {
+      this._abortController.abort();
+      this._abortController = undefined;
+    }
+    this._isRunning = false;
+    this.parentNode!.removeChild(this);
+  }
+
+  private _downloadLogs() {
+    const logs = this._coloredConsole?.logs() || "";
+    textDownload(logs, "update_selected_logs.txt");
+  }
+
+  static styles = [
+    esphomeDialogStyles,
+    css`
+      :host {
+        --height-header-footer-padding: 152px;
+      }
+      mwc-dialog {
+        --mdc-dialog-min-width: 95vw;
+        --mdc-dialog-max-width: 95vw;
+      }
+
+      .status-summary {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 12px;
+        font-size: 13px;
+      }
+
+      .status-badge {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        border-radius: 12px;
+        font-weight: 500;
+      }
+
+      .status-badge::before {
+        content: "";
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+      }
+
+      .status-badge.pending {
+        background: var(--secondary-background-color, #e0e0e0);
+        color: var(--secondary-text-color, #666);
+      }
+      .status-badge.pending::before {
+        background: var(--secondary-text-color, #999);
+      }
+
+      .status-badge.success {
+        background: #e8f5e9;
+        color: #2e7d32;
+      }
+      .status-badge.success::before {
+        background: #4caf50;
+      }
+
+      .status-badge.failed {
+        background: #ffebee;
+        color: #c62828;
+      }
+      .status-badge.failed::before {
+        background: #f44336;
+      }
+
+      .device-list {
+        font-size: 13px;
+        line-height: 1.6;
+        margin-bottom: 12px;
+        color: var(--primary-text-color);
+      }
+
+      .device::before {
+        margin-right: 2px;
+      }
+
+      .device:not(:last-child)::after {
+        content: ", ";
+      }
+
+      .device.pending::before {
+        content: "○";
+        color: var(--secondary-text-color, #999);
+      }
+
+      .device.running::before {
+        content: "◉";
+        color: #2196f3;
+      }
+
+      .device.success::before {
+        content: "✓";
+        color: #4caf50;
+      }
+
+      .device.failed::before {
+        content: "✗";
+        color: #f44336;
+      }
+
+      .log-container {
+        height: calc(60vh - var(--height-header-footer-padding));
+        overflow: auto;
+        background: #1c1c1c;
+        border-radius: 4px;
+        padding: 8px;
+      }
+
+      ${unsafeCSS(coloredConsoleStyles)}
+
+      @media only screen and (max-width: 450px) {
+        .log-container {
+          height: calc(
+            50vh - var(--height-header-footer-padding) - env(
+                safe-area-inset-bottom
+              )
+          );
+          margin-left: -24px;
+          margin-right: -24px;
+        }
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-update-selected-dialog": ESPHomeUpdateSelectedDialog;
+  }
+}


### PR DESCRIPTION
This adds the ability to select and upgrade a batch of devices at a time

Each tile now has a checkbox, and the styling changes a little when selected:
<img width="980" height="290" alt="Screenshot from 2026-01-22 13-13-25" src="https://github.com/user-attachments/assets/67a3512f-4bc0-4d4f-b6c3-b74a78d83520" />

The top of the page changes a bit to reflect this and provide some select all/deselect all buttons
<img width="570" height="129" alt="Screenshot from 2026-01-22 13-13-41" src="https://github.com/user-attachments/assets/a7e763cd-03b5-4e72-9caf-d5f6cf598173" />
<img width="570" height="129" alt="Screenshot from 2026-01-22 13-13-35" src="https://github.com/user-attachments/assets/cf8897bc-e2e2-47dd-bee9-db4e13f66484" />

The installing dialog:

<img width="1228" height="820" alt="image" src="https://github.com/user-attachments/assets/1918c7fe-0146-4344-85ad-bde0fdb24cb6" />

As a disclaimer; I am a fulltime SWE, but I did let claude opus write most of this. With my zero prior experience with lit and your code, it looks like it is sane and matches existing style.
