### PR TITLE
Add Update Online button to update only online devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@material/mwc-fab": "^0.27.0",
         "@material/mwc-formfield": "^0.27.0",
         "@material/mwc-icon-button": "^0.27.0",
+        "@material/mwc-linear-progress": "^0.27.0",
         "@material/mwc-list": "^0.27.0",
         "@material/mwc-menu": "^0.27.0",
         "@material/mwc-radio": "^0.27.0",
@@ -338,6 +339,22 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/linear-progress": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-QqkDBcqX7TMt3zQn51LgS7K0y13rJ4ppMQL1f2uYBhDOov8nqndlaXw456KYE9RhU39JrLzVQlaAbU3eecVb/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/progress-indicator": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/list": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0-canary.53b3cad2f.0.tgz",
@@ -503,6 +520,20 @@
       "integrity": "sha512-n9Xpt5g3RJEl9rvk14OP6dUNJUtsJA46beTQiep7ppO7IPVFLC1v/5sPpUzfNPUBsclSPxdBuNlCxsgcIYueUw==",
       "dependencies": {
         "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-linear-progress": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-linear-progress/-/mwc-linear-progress-0.27.0.tgz",
+      "integrity": "sha512-kpWVLHPb7RzHU70Dq9bl1lBv05S49rQkyfFoL3PU5tEZHozT8IPQjdBLqAqd7H10cfLVjO7oIB+mVmvnFV+UsQ==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/linear-progress": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/theme": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
@@ -925,6 +956,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1708,6 +1740,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -2950,7 +2983,8 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -3221,6 +3255,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3979,6 +4014,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4568,6 +4604,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5032,6 +5069,21 @@
         "tslib": "^2.1.0"
       }
     },
+    "@material/linear-progress": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-QqkDBcqX7TMt3zQn51LgS7K0y13rJ4ppMQL1f2uYBhDOov8nqndlaXw456KYE9RhU39JrLzVQlaAbU3eecVb/Q==",
+      "requires": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/progress-indicator": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "@material/list": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0-canary.53b3cad2f.0.tgz",
@@ -5197,6 +5249,18 @@
       "integrity": "sha512-n9Xpt5g3RJEl9rvk14OP6dUNJUtsJA46beTQiep7ppO7IPVFLC1v/5sPpUzfNPUBsclSPxdBuNlCxsgcIYueUw==",
       "requires": {
         "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "@material/mwc-linear-progress": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-linear-progress/-/mwc-linear-progress-0.27.0.tgz",
+      "integrity": "sha512-kpWVLHPb7RzHU70Dq9bl1lBv05S49rQkyfFoL3PU5tEZHozT8IPQjdBLqAqd7H10cfLVjO7oIB+mVmvnFV+UsQ==",
+      "requires": {
+        "@material/linear-progress": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/theme": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
@@ -5591,7 +5655,8 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
           "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -6079,6 +6144,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
       "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -7010,7 +7076,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ms": {
       "version": "2.0.0",
@@ -7184,6 +7251,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7672,6 +7740,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.57.1",
         "@rollup/rollup-android-arm64": "4.57.1",
@@ -8112,7 +8181,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "universalify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@material/mwc-fab": "^0.27.0",
     "@material/mwc-formfield": "^0.27.0",
     "@material/mwc-icon-button": "^0.27.0",
+    "@material/mwc-linear-progress": "^0.27.0",
     "@material/mwc-list": "^0.27.0",
     "@material/mwc-menu": "^0.27.0",
     "@material/mwc-radio": "^0.27.0",

--- a/src/components/esphome-header-menu.ts
+++ b/src/components/esphome-header-menu.ts
@@ -9,11 +9,14 @@ import type { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import { openEditDialog, toggleSearch } from "../editor";
 import { SECRETS_FILE } from "../api/secrets";
 import { openUpdateAllDialog } from "../update-all";
+import { openUpdateOnlineDialog } from "../update-online";
 import { openCleanAllDialog } from "../clean-all";
 import { showConfirmationDialog } from "../dialogs";
 import { fireEvent } from "../util/fire-event";
 import { mdiBroom } from "@mdi/js";
 import "../components/esphome-svg-icon";
+import { getDevices, canUpdateDevice } from "../api/devices";
+import { getOnlineStatus } from "../api/online-status";
 
 const isWideListener = window.matchMedia("(min-width: 641px)");
 
@@ -26,6 +29,7 @@ export class ESPHomeHeaderMenu extends LitElement {
   @property() discoveredDeviceCount = 0;
 
   @state() private _isWide = isWideListener.matches;
+  @state() private _isLoadingUpdateOnline = false;
 
   protected render(): TemplateResult {
     return html`
@@ -35,6 +39,12 @@ export class ESPHomeHeaderMenu extends LitElement {
               icon="system_update"
               label="Update All"
               @click=${this._handleUpdateAll}
+            ></mwc-button>
+            <mwc-button
+              icon="wifi"
+              .label=${this._isLoadingUpdateOnline ? "Checking..." : "Update Online"}
+              ?disabled=${this._isLoadingUpdateOnline}
+              @click=${this._handleUpdateOnline}
             ></mwc-button>
             <mwc-button label="Clean All Files" @click=${this._handleCleanAll}>
               <esphome-svg-icon
@@ -60,13 +70,13 @@ export class ESPHomeHeaderMenu extends LitElement {
         <mwc-icon-button slot="trigger" icon="more_vert"></mwc-icon-button>
         ${!this._isWide
           ? html`
-              <mwc-list-item graphic="icon"
+              <mwc-list-item graphic="icon" data-action="search"
                 ><mwc-icon slot="graphic">search</mwc-icon>Search</mwc-list-item
               >
             `
           : nothing}
 
-        <mwc-list-item graphic="icon"
+        <mwc-list-item graphic="icon" data-action="toggle-discovered"
           ><mwc-icon slot="graphic">filter_list</mwc-icon>
           ${this.showDiscoveredDevices
             ? "Hide discovered devices"
@@ -75,18 +85,24 @@ export class ESPHomeHeaderMenu extends LitElement {
 
         ${!this._isWide
           ? html`
-              <mwc-list-item graphic="icon"
+              <mwc-list-item graphic="icon" data-action="update-all"
                 ><mwc-icon slot="graphic">system_update</mwc-icon>Update
                 All</mwc-list-item
               >
-              <mwc-list-item graphic="icon"
+              <mwc-list-item
+                graphic="icon"
+                data-action="update-online"
+                ?disabled=${this._isLoadingUpdateOnline}
+                ><mwc-icon slot="graphic">wifi</mwc-icon>${this._isLoadingUpdateOnline ? "Checking..." : "Update Online"}</mwc-list-item
+              >
+              <mwc-list-item graphic="icon" data-action="clean-all"
                 ><esphome-svg-icon
                   slot="graphic"
                   .path=${mdiBroom}
                 ></esphome-svg-icon
                 >Clean All Files</mwc-list-item
               >
-              <mwc-list-item graphic="icon"
+              <mwc-list-item graphic="icon" data-action="secrets"
                 ><mwc-icon slot="graphic">lock</mwc-icon>Secrets
                 Editor</mwc-list-item
               >
@@ -139,33 +155,103 @@ export class ESPHomeHeaderMenu extends LitElement {
     openCleanAllDialog();
   }
 
+  private async _handleUpdateOnline() {
+    if (this._isLoadingUpdateOnline) return;
+
+    this._isLoadingUpdateOnline = true;
+    let devices;
+    let onlineStatus;
+    try {
+      [devices, onlineStatus] = await Promise.all([
+        getDevices(),
+        getOnlineStatus(),
+      ]);
+    } catch (error) {
+      this._isLoadingUpdateOnline = false;
+      alert("Failed to fetch device status. Please try again.");
+      return;
+    }
+    this._isLoadingUpdateOnline = false;
+
+    // Filter to devices that are BOTH online AND have an update available
+    const updatableOnlineDevices = devices.configured.filter(
+      (d) => onlineStatus[d.configuration] === true && canUpdateDevice(d),
+    );
+    const updatableConfigs = updatableOnlineDevices.map((d) => d.configuration);
+
+    // Count devices in different states for the message
+    const totalConfigured = devices.configured.length;
+    const onlineCount = devices.configured.filter(
+      (d) => onlineStatus[d.configuration] === true,
+    ).length;
+    const onlineButCurrentCount = onlineCount - updatableConfigs.length;
+    const offlineCount = totalConfigured - onlineCount;
+
+    if (updatableConfigs.length === 0) {
+      const reasons: string[] = [];
+      if (onlineButCurrentCount > 0) {
+        reasons.push(`${onlineButCurrentCount} online but already up-to-date`);
+      }
+      if (offlineCount > 0) {
+        reasons.push(`${offlineCount} offline/unknown`);
+      }
+      alert(
+        `No devices need updating.\n\n${reasons.join("\n") || "All devices are current."}`,
+      );
+      return;
+    }
+
+    const skippedParts: string[] = [];
+    if (onlineButCurrentCount > 0) {
+      skippedParts.push(`${onlineButCurrentCount} already current`);
+    }
+    if (offlineCount > 0) {
+      skippedParts.push(`${offlineCount} offline`);
+    }
+    const skippedText =
+      skippedParts.length > 0 ? ` (skipping: ${skippedParts.join(", ")})` : "";
+
+    if (
+      !(await showConfirmationDialog({
+        title: "Update Online Devices",
+        text: `Update ${updatableConfigs.length} device${updatableConfigs.length === 1 ? "" : "s"}?${skippedText}`,
+        confirmText: "Update",
+        dismissText: "Cancel",
+      }))
+    ) {
+      return;
+    }
+
+    openUpdateOnlineDialog(updatableConfigs);
+  }
+
   private _handleEditSecrets() {
     openEditDialog(SECRETS_FILE);
   }
 
   private async _handleOverflowAction(ev: CustomEvent<ActionDetail>) {
-    if (this._isWide) {
-      switch (ev.detail.index) {
-        case 0:
-          fireEvent(this, "toggle-discovered-devices");
-          break;
-      }
-      return;
-    }
-    switch (ev.detail.index) {
-      case 0:
+    const menu = ev.currentTarget as HTMLElement;
+    const listItems = menu.querySelectorAll("mwc-list-item[data-action]");
+    const clickedItem = listItems[ev.detail.index] as HTMLElement | undefined;
+    const action = clickedItem?.dataset.action;
+
+    switch (action) {
+      case "search":
         this._handleSearch();
         break;
-      case 1:
+      case "toggle-discovered":
         fireEvent(this, "toggle-discovered-devices");
         break;
-      case 2:
+      case "update-all":
         this._handleUpdateAll();
         break;
-      case 3:
+      case "update-online":
+        this._handleUpdateOnline();
+        break;
+      case "clean-all":
         this._handleCleanAll();
         break;
-      case 4:
+      case "secrets":
         this._handleEditSecrets();
         break;
     }

--- a/src/update-online/index.ts
+++ b/src/update-online/index.ts
@@ -1,0 +1,17 @@
+import type { ESPHomeUpdateOnlineDialog } from "./update-online-dialog";
+
+const preload = () => import("./update-online-dialog");
+
+/**
+ * Opens the Update Online dialog to update multiple devices sequentially.
+ * Each device is compiled and uploaded via OTA, with verification after completion.
+ * @param configurations - Array of device configuration filenames to update
+ */
+export const openUpdateOnlineDialog = (configurations: string[]) => {
+  preload();
+  const dialog = document.createElement(
+    "esphome-update-online-dialog",
+  ) as ESPHomeUpdateOnlineDialog;
+  dialog.configurations = configurations;
+  document.body.append(dialog);
+};

--- a/src/update-online/update-online-dialog.ts
+++ b/src/update-online/update-online-dialog.ts
@@ -1,0 +1,450 @@
+import { LitElement, html, css, unsafeCSS } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import "@material/mwc-dialog";
+import "@material/mwc-button";
+import "@material/mwc-linear-progress";
+import { streamLogs, StreamError } from "../api";
+import { getDevices, canUpdateDevice } from "../api/devices";
+import { ColoredConsole, coloredConsoleStyles } from "../util/console-color";
+import { esphomeDialogStyles } from "../styles";
+import { textDownload } from "../util/file-download";
+
+/** Timeout for compile + upload per device (10 minutes) */
+const DEVICE_UPDATE_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Delay between verification retry attempts (10 seconds) */
+const VERIFICATION_RETRY_DELAY_MS = 10 * 1000;
+
+/** Maximum number of verification attempts */
+const MAX_VERIFICATION_ATTEMPTS = 5;
+
+interface DeviceResult {
+  configuration: string;
+  success: boolean | "pending";
+  error?: string;
+}
+
+@customElement("esphome-update-online-dialog")
+export class ESPHomeUpdateOnlineDialog extends LitElement {
+  @property({ type: Array }) configurations: string[] = [];
+
+  @state() private _currentIndex = 0;
+  @state() private _isRunning = true;
+  @state() private _isVerifying = false;
+  @state() private _verifyingDevice = "";
+  @state() private _verifyAttempt = 0;
+  @state() private _results: DeviceResult[] = [];
+
+  private _coloredConsole?: ColoredConsole;
+  private _abortController?: AbortController;
+
+  protected firstUpdated() {
+    const logDiv = this.shadowRoot!.querySelector(".log") as HTMLDivElement;
+    this._coloredConsole = new ColoredConsole(logDiv);
+    this._startNextDevice();
+  }
+
+  private _getProgress(): number {
+    // Progress is based on completed devices (those with results)
+    if (this.configurations.length === 0) return 0;
+    return this._results.length / this.configurations.length;
+  }
+
+  protected render() {
+    const current = this.configurations[this._currentIndex];
+    const successCount = this._results.filter((r) => r.success === true).length;
+    const failCount = this._results.filter((r) => r.success === false).length;
+    const pendingCount = this._results.filter(
+      (r) => r.success === "pending",
+    ).length;
+
+    return html`
+      <mwc-dialog
+        open
+        heading="Update Online Devices"
+        scrimClickAction
+        @closed=${this._handleClose}
+      >
+        <div class="status" aria-live="polite">
+          ${this._isRunning
+            ? html`
+                <div class="current-device">
+                  Updating: <strong>${current}</strong>
+                  (${this._currentIndex + 1} of ${this.configurations.length})
+                </div>
+                <mwc-linear-progress .progress=${this._getProgress()}></mwc-linear-progress>
+              `
+            : this._isVerifying
+              ? html`
+                  <div class="current-device">
+                    <strong>Verifying: ${this._verifyingDevice}</strong>
+                    (attempt ${this._verifyAttempt} of ${MAX_VERIFICATION_ATTEMPTS})
+                  </div>
+                  <mwc-linear-progress indeterminate></mwc-linear-progress>
+                `
+              : html`
+                  <div class="summary">
+                    <strong>Complete!</strong>
+                    ${successCount > 0
+                      ? html`<span class="success"
+                          >${successCount} verified</span
+                        >`
+                      : ""}
+                    ${pendingCount > 0
+                      ? html`<span class="unverified"
+                          >${pendingCount} unverified</span
+                        >`
+                      : ""}
+                    ${failCount > 0
+                      ? html`<span class="failed">${failCount} failed</span>`
+                      : ""}
+                  </div>
+                  <mwc-linear-progress .progress=${1}></mwc-linear-progress>
+                  <div class="disclaimer">
+                    Note: "Verified" means the device no longer needs an update.
+                    "Unverified" means the upload completed but verification
+                    failed.
+                  </div>
+                `}
+        </div>
+
+        <div class="log"></div>
+
+        <mwc-button
+          slot="secondaryAction"
+          label="Download Logs"
+          @click=${this._downloadLogs}
+        ></mwc-button>
+
+        <mwc-button
+          slot="primaryAction"
+          dialogAction="close"
+          .label=${this._isRunning || this._isVerifying ? "Stop" : "Close"}
+        ></mwc-button>
+      </mwc-dialog>
+    `;
+  }
+
+  /**
+   * Sleep for a specified duration, cancellable via AbortController.
+   * @param ms - Duration in milliseconds
+   * @returns Promise that resolves after delay or rejects if aborted
+   */
+  private _sleep(ms: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(resolve, ms);
+      this._abortController?.signal.addEventListener("abort", () => {
+        clearTimeout(timeoutId);
+        reject(new Error("Aborted"));
+      });
+    });
+  }
+
+  private async _startNextDevice() {
+    if (this._currentIndex >= this.configurations.length) {
+      this._isRunning = false;
+      // Check if we have any pending results that need verification
+      const hasPending = this._results.some((r) => r.success === "pending");
+      if (hasPending) {
+        await this._verifyPendingDevices();
+      }
+      return;
+    }
+
+    const configuration = this.configurations[this._currentIndex];
+    this._coloredConsole?.addLine(
+      `\n\x1b[1;36m========== Updating ${configuration} (${this._currentIndex + 1}/${this.configurations.length}) ==========\x1b[0m\n`,
+    );
+
+    this._abortController = new AbortController();
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        this._abortController?.abort();
+        reject(new Error("Update timed out after 10 minutes"));
+      }, DEVICE_UPDATE_TIMEOUT_MS);
+    });
+
+    // Step 1: Compile (socket closure = failure)
+    this._coloredConsole?.addLine(`\x1b[1;33m>>> Compiling...\x1b[0m\n`);
+    try {
+      await Promise.race([
+        streamLogs(
+          "compile",
+          { configuration },
+          (line) => {
+            this._coloredConsole?.addLine(line);
+          },
+          this._abortController,
+        ),
+        timeoutPromise,
+      ]);
+    } catch (error) {
+      clearTimeout(timeoutId);
+      const streamError = error as StreamError;
+      this._results = [
+        ...this._results,
+        {
+          configuration,
+          success: false,
+          error: `Compile failed: ${streamError.message}`,
+        },
+      ];
+      this._coloredConsole?.addLine(
+        `\x1b[1;31m✗ ${configuration} compile failed: ${streamError.message}\x1b[0m\n`,
+      );
+      this._currentIndex++;
+      try {
+        await this._sleep(500);
+      } catch {
+        return; // Aborted
+      }
+      if (!this.isConnected) return;
+      this._startNextDevice();
+      return;
+    }
+
+    // Step 2: Upload via OTA (socket closure = likely success)
+    this._coloredConsole?.addLine(`\x1b[1;33m>>> Uploading via OTA...\x1b[0m\n`);
+    try {
+      await Promise.race([
+        streamLogs(
+          "upload",
+          { configuration, port: "OTA" },
+          (line) => {
+            this._coloredConsole?.addLine(line);
+          },
+          this._abortController,
+        ),
+        timeoutPromise,
+      ]);
+
+      clearTimeout(timeoutId);
+      this._results = [...this._results, { configuration, success: true }];
+      this._coloredConsole?.addLine(
+        `\x1b[1;32m✓ ${configuration} updated successfully\x1b[0m\n`,
+      );
+    } catch (error) {
+      clearTimeout(timeoutId);
+      const streamError = error as StreamError;
+      // Socket closure during upload often means OTA completed successfully
+      // Mark as pending for verification after all updates complete
+      const isSocketClosure = streamError.message?.includes("socket closure");
+      if (isSocketClosure) {
+        this._results = [...this._results, { configuration, success: "pending" }];
+        this._coloredConsole?.addLine(
+          `\x1b[1;33m? ${configuration} upload completed (pending verification)\x1b[0m\n`,
+        );
+      } else {
+        this._results = [
+          ...this._results,
+          {
+            configuration,
+            success: false,
+            error: `Upload failed: ${streamError.message}`,
+          },
+        ];
+        this._coloredConsole?.addLine(
+          `\x1b[1;31m✗ ${configuration} upload failed: ${streamError.message}\x1b[0m\n`,
+        );
+      }
+    }
+
+    this._currentIndex++;
+    this.requestUpdate();
+
+    // Small delay before starting next device
+    try {
+      await this._sleep(500);
+    } catch {
+      return; // Aborted
+    }
+    if (!this.isConnected) return;
+    this._startNextDevice();
+  }
+
+  private async _verifyPendingDevices() {
+    this._isVerifying = true;
+    this._abortController = new AbortController();
+
+    const pendingConfigs = this._results
+      .filter((r) => r.success === "pending")
+      .map((r) => r.configuration);
+
+    this._coloredConsole?.addLine(
+      `\n\x1b[1;36m========== Verifying ${pendingConfigs.length} device(s) ==========\x1b[0m\n`,
+    );
+
+    for (
+      this._verifyAttempt = 1;
+      this._verifyAttempt <= MAX_VERIFICATION_ATTEMPTS;
+      this._verifyAttempt++
+    ) {
+      const stillPending = this._results.filter((r) => r.success === "pending");
+      if (stillPending.length === 0) {
+        break;
+      }
+
+      if (this._verifyAttempt > 1) {
+        this._coloredConsole?.addLine(
+          `\x1b[1;33mWaiting 10 seconds before retry (attempt ${this._verifyAttempt}/${MAX_VERIFICATION_ATTEMPTS})...\x1b[0m\n`,
+        );
+        try {
+          await this._sleep(VERIFICATION_RETRY_DELAY_MS);
+        } catch {
+          break; // Aborted
+        }
+        if (!this.isConnected) return;
+      } else {
+        this._coloredConsole?.addLine(
+          `\x1b[1;33mChecking device status...\x1b[0m\n`,
+        );
+      }
+
+      try {
+        const devices = await getDevices();
+
+        // Use immutable update for proper LitElement reactivity
+        this._results = this._results.map((result) => {
+          if (result.success !== "pending") return result;
+
+          this._verifyingDevice = result.configuration;
+
+          const device = devices.configured.find(
+            (d) => d.configuration === result.configuration,
+          );
+
+          if (device && !canUpdateDevice(device)) {
+            // Device no longer needs update = success
+            this._coloredConsole?.addLine(
+              `\x1b[1;32m✓ ${result.configuration} verified (no longer needs update)\x1b[0m\n`,
+            );
+            return { ...result, success: true as const };
+          } else if (device && canUpdateDevice(device)) {
+            // Device still needs update = failed
+            this._coloredConsole?.addLine(
+              `\x1b[1;31m✗ ${result.configuration} failed (still needs update)\x1b[0m\n`,
+            );
+            return {
+              ...result,
+              success: false as const,
+              error: "Device still requires update after OTA",
+            };
+          } else {
+            // Can't determine - keep as pending for retry
+            this._coloredConsole?.addLine(
+              `\x1b[1;33m? ${result.configuration} not yet online (will retry)\x1b[0m\n`,
+            );
+            return result;
+          }
+        });
+      } catch (error) {
+        this._coloredConsole?.addLine(
+          `\x1b[1;31mVerification attempt failed: Could not fetch device status\x1b[0m\n`,
+        );
+        // Continue to retry
+      }
+
+      this.requestUpdate();
+    }
+
+    // Mark any remaining pending as unverified
+    const finalPending = this._results.filter((r) => r.success === "pending");
+    if (finalPending.length > 0) {
+      this._coloredConsole?.addLine(
+        `\x1b[1;33m${finalPending.length} device(s) could not be verified after ${MAX_VERIFICATION_ATTEMPTS} attempts\x1b[0m\n`,
+      );
+    }
+
+    this._isVerifying = false;
+    this._verifyingDevice = "";
+    this.requestUpdate();
+  }
+
+  private _downloadLogs() {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    textDownload(
+      this._coloredConsole?.logs() || "",
+      `update-online-${timestamp}.txt`,
+    );
+  }
+
+  private _handleClose() {
+    if (this._abortController) {
+      this._abortController.abort();
+    }
+    this.parentNode!.removeChild(this);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._abortController) {
+      this._abortController.abort();
+    }
+  }
+
+  static styles = [
+    esphomeDialogStyles,
+    css`
+      :host {
+        --height-header-footer-padding: 180px;
+      }
+      mwc-dialog {
+        --mdc-dialog-min-width: 95vw;
+        --mdc-dialog-max-width: 95vw;
+      }
+      .status {
+        margin-bottom: 16px;
+      }
+      .current-device {
+        margin-bottom: 8px;
+      }
+      mwc-linear-progress {
+        margin: 8px 0;
+      }
+      .summary {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+      }
+      .success {
+        color: var(--status-connected, #4caf50);
+      }
+      .unverified {
+        color: var(--alert-warning-color, #ff9800);
+      }
+      .failed {
+        color: var(--alert-error-color, #f44336);
+      }
+      .disclaimer {
+        margin-top: 8px;
+        font-size: 12px;
+        color: var(--secondary-text-color, #888);
+        font-style: italic;
+      }
+      .log {
+        height: calc(90vh - var(--height-header-footer-padding));
+      }
+      ${unsafeCSS(coloredConsoleStyles)}
+      @media (max-width: 450px) {
+        .log {
+          height: calc(
+            90vh - var(--height-header-footer-padding) - env(
+                safe-area-inset-bottom
+              )
+          );
+          margin-left: -24px;
+          margin-right: -24px;
+        }
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "esphome-update-online-dialog": ESPHomeUpdateOnlineDialog;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an "Update Online" button that intelligently updates only devices that are:
- Currently online (responding to ping)
- Have an update available (deployed version differs from current ESPHome version)

This complements the existing "Update All" button by skipping offline devices and devices already running the current version, reducing failed OTA attempts and wasted compile time.

## Features

- **Smart filtering**: Fetches device list and online status, filters to updatable online devices
- **Clear feedback**: Shows confirmation dialog with counts (X to update, Y already current, Z offline)
- **Sequential processing**: Compiles and uploads each device one at a time via OTA
- **Progress tracking**: Shows current device, progress bar, and success/failure counts
- **Downloadable logs**: Full compile/upload output can be downloaded for troubleshooting
- **Colored console**: ANSI color codes rendered for readable output

## Implementation

**Frontend-only approach** - No backend modifications required. Uses existing WebSocket endpoints:
- `GET ./devices` - List configured devices with version info
- `GET ./ping` - Get online status map
- `WS ./compile` - Compile configuration
- `WS ./upload` - Upload firmware via OTA

### Files changed

| File | Change |
|------|--------|
| `src/components/esphome-header-menu.ts` | Add button and click handler with device filtering logic |
| `src/update-online/index.ts` | New - lazy loader for dialog |
| `src/update-online/update-online-dialog.ts` | New - dialog with compile+upload workflow |
| `package.json` | Add `@material/mwc-linear-progress` dependency |

## Screenshots

_(Button appears next to "Update All" in the header menu)_

## Test plan

- [ ] Click "Update Online" with mix of online/offline devices - verify correct filtering
- [ ] Verify devices already at current version are skipped
- [ ] Verify compile failure stops that device but continues to next
- [ ] Verify OTA upload completes successfully for online devices
- [ ] Test "Download Logs" button captures full output
- [ ] Test "Stop" button aborts current operation
- [ ] Verify narrow screen overflow menu includes the new option