### PR TITLE
Add pre-build status snackbar notifications

### DIFF
--- a/src/api/dashboard-events.ts
+++ b/src/api/dashboard-events.ts
@@ -12,6 +12,7 @@ export const ServerEvent = {
   IMPORTABLE_DEVICE_ADDED: "importable_device_added",
   IMPORTABLE_DEVICE_REMOVED: "importable_device_removed",
   INITIAL_STATE: "initial_state",
+  PRE_BUILD_STATUS: "pre_build_status",
   PONG: "pong",
 } as const;
 

--- a/src/esphome-main.ts
+++ b/src/esphome-main.ts
@@ -4,6 +4,7 @@ import "./components/esphome-fab";
 import { LitElement, html, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { connectionStatus } from "./util/connection-status";
+import { preBuildStatus } from "./util/pre-build-status";
 
 @customElement("esphome-main")
 class ESPHomeMainView extends LitElement {
@@ -74,6 +75,7 @@ class ESPHomeMainView extends LitElement {
   protected firstUpdated(changedProps: PropertyValues): void {
     super.firstUpdated(changedProps);
     connectionStatus.initialize();
+    preBuildStatus.initialize();
     document.body.addEventListener<any>("edit-file", (ev) => {
       this.editing = ev.detail;
     });

--- a/src/util/pre-build-status.ts
+++ b/src/util/pre-build-status.ts
@@ -1,0 +1,70 @@
+import "@material/mwc-snackbar";
+import type { Snackbar } from "@material/mwc-snackbar";
+import { dashboardWebSocket } from "../api/websocket";
+import { ServerEvent } from "../api/dashboard-events";
+
+interface PreBuildEventData {
+  status: string;
+  total?: number;
+  version?: string;
+  filename?: string;
+  name?: string;
+  error?: string;
+  current?: number;
+  succeeded?: number;
+  failed?: number;
+}
+
+class PreBuildStatus {
+  private snackbar: Snackbar | null = null;
+
+  public initialize(): void {
+    if (!this.snackbar) {
+      this.snackbar = document.createElement("mwc-snackbar") as Snackbar;
+      this.snackbar.stacked = false;
+      this.snackbar.leading = false;
+      document.body.appendChild(this.snackbar);
+    }
+
+    dashboardWebSocket.on(
+      ServerEvent.PRE_BUILD_STATUS,
+      (data: PreBuildEventData) => {
+        this.handleEvent(data);
+      },
+    );
+  }
+
+  private handleEvent(data: PreBuildEventData): void {
+    if (!this.snackbar) return;
+
+    switch (data.status) {
+      case "started":
+        this.snackbar.labelText = `Pre-building firmware for ${data.total} device(s)...`;
+        this.snackbar.timeoutMs = -1;
+        this.snackbar.show();
+        break;
+
+      case "device_done":
+        this.snackbar.labelText = `Built ${data.name} (${data.current}/${data.total})...`;
+        break;
+
+      case "device_failed":
+        this.snackbar.labelText = `Failed to build ${data.name} (${data.current}/${data.total})...`;
+        break;
+
+      case "finished":
+        this.snackbar.labelText = `Pre-build complete: ${data.succeeded} succeeded, ${data.failed} failed`;
+        this.snackbar.timeoutMs = 8000;
+        // Close and re-show to apply new timeout
+        this.snackbar.close();
+        setTimeout(() => {
+          if (this.snackbar) {
+            this.snackbar.show();
+          }
+        }, 100);
+        break;
+    }
+  }
+}
+
+export const preBuildStatus = new PreBuildStatus();


### PR DESCRIPTION
# What does this implement/fix?                                                                                                                                                       
                                                                                     
Support PR for adding automatic firmware pre-building on dashboard startup. When the ESPHome dashboard starts, it checks all configured devices and automatically compiles firmware for any device  whose stored build version doesn't match the current ESPHome version (`update_available == True`). This eliminates the manual step of re-compiling each device after an ESPHome upgrade. This PR is the dashboard UI counterpart.

[Related discussion](https://github.com/orgs/esphome/discussions/3540)

There is also a [esphome](https://github.com/esphome/esphome/pull/14337) PR for the logic 
And a [Docs](https://github.com/esphome/esphome-docs/pull/6167) PR
                                                                                     
  Key behaviors:
  - Runs as a background task so dashboard startup is not blocked
  - Fires `PRE_BUILD_STATUS` events over WebSocket so the frontend can show progress
  - Restores the storage JSON version on failed builds so the next restart retries them
  - Skips pre-build entirely if all devices are already up to date

  ## Types of changes

  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) —
  [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
  - [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
  - [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) —
  [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
  - [ ] Code quality improvements to existing code or addition of tests
  - [ ] Other

  **Related issue or feature (if applicable):**

  - N/A

  **Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

  - N/A

  ## Test Environment

  - [ ] ESP32
  - [ ] ESP32 IDF
  - [ ] ESP8266
  - [ ] RP2040
  - [ ] BK72xx
  - [ ] RTL87xx
  - [ ] LN882x
  - [ ] nRF52840

  ## Example entry for `config.yaml`:

  ```yaml
  # No configuration needed — pre-build runs automatically on dashboard startup
  # for any device whose firmware was built with an older ESPHome version.

  Checklist:

  - The code change is tested and works locally.
  - Tests have been added to verify that the new code works (under tests/ folder).

  If user exposed functionality or configuration variables are added/changed:
  - Documentation added/updated in https://github.com/esphome/esphome-docs.