### PR TITLE
Fix improv_serial initialization failure after "Prepare for First Use"

### DIFF
--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -23,6 +23,7 @@ import {
 } from "../const";
 import { esphomeDialogStyles } from "../styles";
 import { sleep } from "../util/sleep";
+import { resetSerialDevice } from "../web-serial/reset-serial-device";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
@@ -241,6 +242,7 @@ export class ESPHomeInstallWebDialog extends LitElement {
       }
 
       await esploader.after();
+      await resetSerialDevice(esploader.transport);
       this._state = "done";
     } finally {
       console.log("Closing port");


### PR DESCRIPTION
**Problem**
After completing "Prepare for First Use" (device flashing), the improv_serial component fails to initialize because the UART buffer contains residual data from the flashing process and device boot sequence. This causes improv_serial to fail parsing the initial handshake.

<img width="397" height="229" alt="image" src="https://github.com/user-attachments/assets/92f7e332-33a9-4203-b975-123ad3e70ef7" />

**Solution**
Add a device reset (RTS pulse) at the end of the installation process, before handing control to improv_serial. This clears the serial buffer and allows improv_serial to start with a clean state.

**Changes**

- Import resetSerialDevice utility
- Call resetSerialDevice(esploader.transport) after successful firmware installation

The reset uses the same RTS pulse mechanism as the existing "Reset Device" button in the logs view.

**Testing**
Load website with HTTPS
Use "Prepare for First Use" to flash a device
Proceed to "Configure Wi-Fi"
improv_serial should now successfully initialize and allow Wi-Fi configuration