### PR TITLE
Add 'Show entity state changes' toggle to OTA log viewer

### DIFF
--- a/src/components/process-dialog.ts
+++ b/src/components/process-dialog.ts
@@ -43,7 +43,7 @@ export class ESPHomeProcessDialog extends LitElement {
             @process-done=${this._handleProcessDone}
           ></esphome-remote-process>
 
-          <div class="action-row">
+          <div class="action-row" @click=${this._handleActionRowClick}>
             ${this.showStatesToggle
               ? html`
                   <mwc-formfield label="Show entity state changes">
@@ -74,6 +74,17 @@ export class ESPHomeProcessDialog extends LitElement {
 
   private _closeDialog() {
     this.shadowRoot?.querySelector("mwc-dialog")?.close();
+  }
+
+  // mwc-dialog's built-in dialogAction click delegation only walks closest()
+  // from mdcRoot's listener, which can't reach slotted buttons now that we
+  // render the action row in the content slot. Mirror the behaviour here so
+  // existing `dialogAction="close"` buttons keep closing the dialog.
+  private _handleActionRowClick(ev: MouseEvent) {
+    const target = ev.target as Element | null;
+    if (target?.closest("[dialogAction]")) {
+      this._closeDialog();
+    }
   }
 
   public restart() {

--- a/src/components/process-dialog.ts
+++ b/src/components/process-dialog.ts
@@ -78,9 +78,7 @@ export class ESPHomeProcessDialog extends LitElement {
 
   public restart() {
     this._result = undefined;
-    this.shadowRoot
-      ?.querySelector("esphome-remote-process")
-      ?.restart();
+    this.shadowRoot?.querySelector("esphome-remote-process")?.restart();
   }
 
   private _onToggleShowStates(ev: Event) {

--- a/src/components/process-dialog.ts
+++ b/src/components/process-dialog.ts
@@ -2,6 +2,8 @@ import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "@material/mwc-dialog";
 import "@material/mwc-button";
+import "@material/mwc-checkbox";
+import "@material/mwc-formfield";
 import "../components/remote-process";
 import { fireEvent } from "../util/fire-event";
 import { esphomeDialogStyles } from "../styles";
@@ -17,39 +19,73 @@ export class ESPHomeProcessDialog extends LitElement {
   @property({ type: Boolean, attribute: "always-show-close" })
   public alwaysShowClose = false;
 
+  @property({ type: Boolean, attribute: "show-states-toggle" })
+  public showStatesToggle = false;
+
+  @property({ type: Boolean, attribute: "show-states" })
+  public showStates = true;
+
   @state() private _result?: number;
 
   protected render() {
     return html`
       <mwc-dialog
         open
+        hideActions
         heading=${this.heading}
         scrimClickAction
         @closed=${this._handleClose}
       >
-        <esphome-remote-process
-          .type=${this.type}
-          .spawnParams=${this.spawnParams}
-          @process-done=${this._handleProcessDone}
-        ></esphome-remote-process>
+        <div class="body">
+          <esphome-remote-process
+            .type=${this.type}
+            .spawnParams=${this.spawnParams}
+            @process-done=${this._handleProcessDone}
+          ></esphome-remote-process>
 
-        <mwc-button
-          slot="secondaryAction"
-          label="Download Logs"
-          @click=${this._downloadLogs}
-        ></mwc-button>
-
-        <slot name="secondaryAction" slot="secondaryAction"></slot>
-
-        <mwc-button
-          slot="primaryAction"
-          dialogAction="close"
-          .label=${this._result === undefined && !this.alwaysShowClose
-            ? "Stop"
-            : "Close"}
-        ></mwc-button>
+          <div class="action-row">
+            ${this.showStatesToggle
+              ? html`
+                  <mwc-formfield label="Show entity state changes">
+                    <mwc-checkbox
+                      ?checked=${this.showStates}
+                      @change=${this._onToggleShowStates}
+                    ></mwc-checkbox>
+                  </mwc-formfield>
+                `
+              : ""}
+            <span class="spacer"></span>
+            <mwc-button
+              label="Download Logs"
+              @click=${this._downloadLogs}
+            ></mwc-button>
+            <slot name="secondaryAction"></slot>
+            <mwc-button
+              @click=${this._closeDialog}
+              .label=${this._result === undefined && !this.alwaysShowClose
+                ? "Stop"
+                : "Close"}
+            ></mwc-button>
+          </div>
+        </div>
       </mwc-dialog>
     `;
+  }
+
+  private _closeDialog() {
+    this.shadowRoot?.querySelector("mwc-dialog")?.close();
+  }
+
+  public restart() {
+    this._result = undefined;
+    this.shadowRoot
+      ?.querySelector("esphome-remote-process")
+      ?.restart();
+  }
+
+  private _onToggleShowStates(ev: Event) {
+    const checked = (ev.target as HTMLInputElement).checked;
+    fireEvent(this, "show-states-changed", checked);
   }
 
   private _handleProcessDone(ev: { detail: number }) {
@@ -78,24 +114,47 @@ export class ESPHomeProcessDialog extends LitElement {
     esphomeDialogStyles,
     css`
       :host {
-        --height-header-footer-padding: 152px;
+        /* Header height (~64px). mwc-dialog's hardcoded content padding
+           (20px top + 20px bottom) is absorbed by the .body negative margin
+           below, and hideActions removes the 52px footer. */
+        --height-header-footer-padding: 80px;
       }
       mwc-dialog {
         --mdc-dialog-min-width: 95vw;
         --mdc-dialog-max-width: 95vw;
       }
 
-      esphome-remote-process {
+      .body {
+        display: flex;
+        flex-direction: column;
         height: calc(90vh - var(--height-header-footer-padding));
+        /* Cancel mwc-dialog's hardcoded 20px top/bottom content padding. */
+        margin: -20px 0;
+      }
+      esphome-remote-process {
+        flex: 1;
+        min-height: 0;
+      }
+      .action-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 0;
+        width: 100%;
+      }
+      .spacer {
+        flex: 1 1 auto;
       }
 
       @media only screen and (max-width: 450px) {
-        esphome-remote-process {
+        .body {
           height: calc(
             90vh - var(--height-header-footer-padding) - env(
                 safe-area-inset-bottom
               )
           );
+        }
+        esphome-remote-process {
           margin-left: -24px;
           margin-right: -24px;
         }

--- a/src/components/remote-process.ts
+++ b/src/components/remote-process.ts
@@ -31,23 +31,39 @@ class ESPHomeRemoteProcess extends HTMLElement {
       <div class="log"></div>
     `;
 
-    const coloredConsole = new ColoredConsole(shadowRoot.querySelector("div")!);
-    this._coloredConsole = coloredConsole;
-    this._abortController = new AbortController();
+    this._coloredConsole = new ColoredConsole(shadowRoot.querySelector("div")!);
+    this._startStream();
+  }
+
+  public restart() {
+    this._startStream();
+  }
+
+  private _startStream() {
+    if (this._abortController) {
+      this._abortController.abort();
+    }
+    const controller = new AbortController();
+    this._abortController = controller;
 
     streamLogs(
       this.type,
       this.spawnParams,
       (line) => {
-        coloredConsole.addLine(line);
+        this._coloredConsole?.addLine(line);
       },
-      this._abortController,
+      controller,
     ).then(
       () => {
-        fireEvent(this, "process-done", 0);
+        // Ignore the resolution of a stream we have already replaced.
+        if (this._abortController === controller) {
+          fireEvent(this, "process-done", 0);
+        }
       },
       (error: StreamError) => {
-        fireEvent(this, "process-done", error.code);
+        if (this._abortController === controller) {
+          fireEvent(this, "process-done", error.code);
+        }
       },
     );
   }

--- a/src/logs/logs-dialog.ts
+++ b/src/logs/logs-dialog.ts
@@ -20,7 +20,8 @@ class ESPHomeLogsDialog extends LitElement {
   @state() private _showStates: boolean =
     localStorage.getItem(SHOW_STATES_STORAGE_KEY) !== "false";
 
-  @query("esphome-process-dialog") private _processDialog!: ESPHomeProcessDialog;
+  @query("esphome-process-dialog")
+  private _processDialog!: ESPHomeProcessDialog;
 
   protected render() {
     return html`

--- a/src/logs/logs-dialog.ts
+++ b/src/logs/logs-dialog.ts
@@ -11,14 +11,31 @@ import { esphomeDialogStyles } from "../styles";
 
 const SHOW_STATES_STORAGE_KEY = "esphome-logs-show-states";
 
+// Safari private mode and locked-down browser contexts can throw on any
+// localStorage access; fall back to the default and silently swallow writes.
+const readShowStates = (): boolean => {
+  try {
+    return localStorage.getItem(SHOW_STATES_STORAGE_KEY) !== "false";
+  } catch {
+    return true;
+  }
+};
+
+const writeShowStates = (value: boolean): void => {
+  try {
+    localStorage.setItem(SHOW_STATES_STORAGE_KEY, String(value));
+  } catch {
+    // ignore
+  }
+};
+
 @customElement("esphome-logs-dialog")
 class ESPHomeLogsDialog extends LitElement {
   @property() public configuration!: string;
   @property() public target!: string;
 
   @state() private _result?: number;
-  @state() private _showStates: boolean =
-    localStorage.getItem(SHOW_STATES_STORAGE_KEY) !== "false";
+  @state() private _showStates: boolean = readShowStates();
 
   @query("esphome-process-dialog")
   private _processDialog!: ESPHomeProcessDialog;
@@ -74,7 +91,7 @@ class ESPHomeLogsDialog extends LitElement {
 
   private async _toggleShowStates(ev: CustomEvent<boolean>) {
     this._showStates = ev.detail;
-    localStorage.setItem(SHOW_STATES_STORAGE_KEY, String(this._showStates));
+    writeShowStates(this._showStates);
     this._result = undefined;
     // Wait for our render plus the inner process-dialog render so the new
     // spawnParams reach esphome-remote-process before we restart the stream.

--- a/src/logs/logs-dialog.ts
+++ b/src/logs/logs-dialog.ts
@@ -1,12 +1,15 @@
 import { LitElement, html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import "@material/mwc-button";
 import "@material/mwc-list/mwc-list-item.js";
 import "../components/remote-process";
 import { openEditDialog } from "../editor";
 import "../components/process-dialog";
+import type { ESPHomeProcessDialog } from "../components/process-dialog";
 import { openLogsDialog } from ".";
 import { esphomeDialogStyles } from "../styles";
+
+const SHOW_STATES_STORAGE_KEY = "esphome-logs-show-states";
 
 @customElement("esphome-logs-dialog")
 class ESPHomeLogsDialog extends LitElement {
@@ -14,16 +17,27 @@ class ESPHomeLogsDialog extends LitElement {
   @property() public target!: string;
 
   @state() private _result?: number;
+  @state() private _showStates: boolean =
+    localStorage.getItem(SHOW_STATES_STORAGE_KEY) !== "false";
+
+  @query("esphome-process-dialog") private _processDialog!: ESPHomeProcessDialog;
 
   protected render() {
     return html`
       <esphome-process-dialog
         always-show-close
+        ?show-states-toggle=${this.target === "OTA"}
+        .showStates=${this._showStates}
         .heading=${`Logs ${this.configuration}`}
         .type=${"logs"}
-        .spawnParams=${{ configuration: this.configuration, port: this.target }}
+        .spawnParams=${{
+          configuration: this.configuration,
+          port: this.target,
+          no_states: !this._showStates,
+        }}
         @closed=${this._handleClose}
         @process-done=${this._handleProcessDone}
+        @show-states-changed=${this._toggleShowStates}
       >
         <mwc-button
           slot="secondaryAction"
@@ -55,6 +69,17 @@ class ESPHomeLogsDialog extends LitElement {
 
   private _handleRetry() {
     openLogsDialog(this.configuration, this.target);
+  }
+
+  private async _toggleShowStates(ev: CustomEvent<boolean>) {
+    this._showStates = ev.detail;
+    localStorage.setItem(SHOW_STATES_STORAGE_KEY, String(this._showStates));
+    this._result = undefined;
+    // Wait for our render plus the inner process-dialog render so the new
+    // spawnParams reach esphome-remote-process before we restart the stream.
+    await this.updateComplete;
+    await this._processDialog?.updateComplete;
+    this._processDialog?.restart();
   }
 
   private _handleClose() {


### PR DESCRIPTION
## Context

The dashboard is slated to be replaced by a new system in the future. This PR is the minimal short-term change needed to fill the gap so users running the current dashboard have a way to opt out of entity-state log spam without dropping to a shell.

## Summary

ESPHome 2026.4.0 introduced `[S][sensor]` / `[S][text_sensor]` entity-state log lines that aren't suppressed by the existing `logger:` level/tag filters. The CLI ships `esphome logs --no-states` for this, but the dashboard had no UI escape hatch (issues [esphome/esphome#15987](https://github.com/esphome/esphome/issues/15987) and [esphome/esphome#15865](https://github.com/esphome/esphome/issues/15865)).

This adds a **"Show entity state changes"** checkbox to the bottom-left of the logs dialog. Toggling it sends `no_states` in the WebSocket spawn message (handled by the companion backend PR [esphome/esphome#15993](https://github.com/esphome/esphome/pull/15993)) and reconnects the log stream so the change takes effect immediately. The choice persists in `localStorage`.

The toggle is gated to OTA targets only — `--no-states` has no effect on serial logs (`run_miniterm` ignores it) and WebSerial logs run entirely in the browser.

<img width="1201" height="615" alt="Screenshot 2026-04-25 at 7 51 12 AM" src="https://github.com/user-attachments/assets/898d43ba-fed5-4c28-8976-1585302856b4" />

Mobile

<img width="309" height="637" alt="Screenshot 2026-04-25 at 8 45 16 AM" src="https://github.com/user-attachments/assets/dbea441a-7b79-4735-b448-089e3ae608ce" />


## Layout / refactor notes

- mwc-dialog's actions footer is hidden via the existing `hideActions` property; the entire bottom row (checkbox, Download Logs, secondaryAction slot, Close) is owned by `process-dialog` so the checkbox can sit at the dialog's left edge with the buttons flush right. Trying to do this via mwc-dialog's `primaryAction` / `secondaryAction` slots fights `mdc-dialog__actions { justify-content: flex-end }` and the `#actions ::slotted(*) { max-width: 100%; text-align: right }` rules — owning the row gives deterministic layout.
- `esphome-remote-process` gets a public `restart()` and tags each `streamLogs()` call with its `AbortController` so the stale connection's resolution can't fire `process-done` after the new one is started.
- `process-dialog` gets `show-states-toggle` / `.showStates` properties and emits `show-states-changed`; `logs-dialog` owns the persisted state and orchestrates the restart.

## Test plan

- [x] Open Logs on an OTA-reachable device — checkbox appears at left, buttons at right, single row.
- [x] Untick the checkbox — `[S][sensor]` lines stop streaming; backend log shows `--no-states` in the spawned argv.
- [x] Re-tick — state lines resume.
- [x] Close + reopen the dialog — checkbox state persists (`localStorage.esphome-logs-show-states`).
- [x] ESC key and scrim click still close the dialog.
- [x] Open Logs against a server serial port (`/dev/ttyXXX`) — checkbox is hidden.
- [x] WebSerial path ("Plug into this computer") is untouched (separate dialog).
