### PR TITLE
Bump version to 20260425.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as readme:
 
 setup(
     name="esphome-dashboard",
-    version="20260408.1",
+    version="20260425.0",
     description="ESPHome Device Builder",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
- Bump version to 20260425.0 to cut a new dashboard release
- Includes #902 (entity state changes toggle in OTA log viewer) and #896 (release-drafter bump) since 20260408.1

## Test plan
- [ ] Merge triggers release-drafter to update the draft tag to `20260425.0`
- [ ] Publishing the release fires `pythonpublish.yml` and uploads `esphome-dashboard==20260425.0` to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)