### PR TITLE
Mark this repository as deprecated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
-# ESPHome Dashboard
+# ESPHome Dashboard (Legacy)
+
+> ## :warning: This project is no longer actively developed
+>
+> The ESPHome dashboard in this repository has been replaced by
+> [**ESPHome Device Builder**](https://github.com/esphome/device-builder),
+> which is where all new development is happening.
+>
+> ### What this means
+>
+> - **No new features** will be accepted here. Please open feature
+>   pull requests against [esphome/device-builder](https://github.com/esphome/device-builder).
+> - **Bug fixes**: small fixes may still be considered, but check whether the
+>   same issue exists in Device Builder first; that's where the fix will have
+>   a longer life.
+> - **Security fixes only** will continue to ship from this repository while
+>   it remains embedded in ESPHome releases. Please report security issues
+>   privately via
+>   [GitHub security advisories](https://github.com/esphome/dashboard/security/advisories/new)
+>   rather than opening a public issue or pull request.
+> - **Pull requests** that add functionality here will most likely be closed
+>   with a pointer to Device Builder. We appreciate the contribution and
+>   apologize for the friction; this notice is here so your time isn't spent
+>   on a change that won't land.
+
+---
 
 The ESPHome Device Builder is a user facing dashboard embedded in ESPHome. It allows users to easily create and manage their configurations.
 


### PR DESCRIPTION
## Summary

The dashboard in this repository is being replaced by [esphome/device-builder](https://github.com/esphome/device-builder), and new feature work has moved there. Today contributors are typically only told this *after* opening a pull request (see e.g. [esphome/esphome#15485](https://github.com/esphome/esphome/pull/15485)), which is frustrating for them and wastes review cycles.

This PR adds a clear, friendly deprecation banner to the README so that visitors and would-be contributors learn the situation immediately:

- New features → please open against esphome/device-builder.
- Bug fixes → still considered, but check Device Builder first.
- Security issues → please report privately via GitHub security advisories rather than as a public PR.
- Pull requests adding functionality here will most likely be closed with a pointer to Device Builder.

The "Development" section is preserved underneath, since the repo is still embedded in ESPHome releases and security fixes will still ship from here.

A companion PR in esphome/esphome adds a GitHub Actions bot that posts the same message on PRs touching `esphome/dashboard/` or `tests/dashboard/`, so contributors who land there directly also get the heads up.