### PR TITLE
Verify YAML editor saves before opening install dialog

### DIFF
--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -1,12 +1,16 @@
 import { APIError, fetchApiText } from ".";
 
+const editUrl = (filename: string): string => {
+  const urlSearchParams = new URLSearchParams({
+    configuration: filename,
+  });
+  return `./edit?${urlSearchParams.toString()}`;
+};
+
 // null if file not found.
 export const getFile = async (filename: string): Promise<string | null> => {
   try {
-    const urlSearchParams = new URLSearchParams({
-      configuration: filename,
-    });
-    return fetchApiText(`./edit?${urlSearchParams.toString()}`);
+    return fetchApiText(editUrl(filename), { cache: "no-store" });
   } catch (err) {
     if (err instanceof APIError && err.status === 404) {
       return null;
@@ -19,11 +23,18 @@ export const writeFile = async (
   filename: string,
   content: string,
 ): Promise<string> => {
-  const urlSearchParams = new URLSearchParams({
-    configuration: filename,
-  });
-  return fetchApiText(`./edit?${urlSearchParams.toString()}`, {
+  const url = editUrl(filename);
+  await fetchApiText(url, {
     method: "POST",
     body: content,
+    cache: "no-store",
   });
+
+  const savedContent = await fetchApiText(url, { cache: "no-store" });
+  if (savedContent !== content) {
+    throw new Error(
+      "Save verification failed: saved content does not match editor content",
+    );
+  }
+  return savedContent;
 };

--- a/src/editor/esphome-editor.ts
+++ b/src/editor/esphome-editor.ts
@@ -114,11 +114,14 @@ class ESPHomeEditor extends LitElement {
   }
 
   private async handleInstall() {
-    await this._saveFile();
+    const saved = await this._saveFile();
+    if (!saved) {
+      return;
+    }
     openInstallChooseDialog(this.fileName);
   }
 
-  private async _saveFile() {
+  private async _saveFile(): Promise<boolean> {
     const code = this.getValue();
     if (this._snackbar.open) {
       this._snackbar.close();
@@ -127,8 +130,10 @@ class ESPHomeEditor extends LitElement {
     try {
       await writeFile(this.fileName, code ?? "");
       this._showSnackbar(`✅ Saved ${this.fileName}`);
+      return true;
     } catch (error) {
       this._showSnackbar(`❌ An error occurred saving ${this.fileName}`);
+      return false;
     }
   }
 


### PR DESCRIPTION
I've noticed that sometimes I get a "saved" popup, when I try to select 'install' in the ESPHome Web UI, while the browser is actually in some kind of hung up state. It will then show the selection of install options, but when I select the option device plugged into ESPHome server, I get just a "waiting for response circle animation". When I hit F5 after 2-3 minutes, I get the page reloaded, but my changes are gone - and this despite the UI showing, that the changes are successfully stored.

To counteract this [I implemented a cache no store flag on the server](https://github.com/esphome/esphome/pull/16495) and the client, compare the read back and also avoid showing the install popup when storing wasn't successful.