### PR TITLE
Add Firefox to list of supported WebSerial browsers

### DIFF
--- a/web.esphome.io/src/dashboard/unsupported-card.ts
+++ b/web.esphome.io/src/dashboard/unsupported-card.ts
@@ -11,7 +11,8 @@ class EWUnsupportedCard extends LitElement {
         <div class="card-header">Dashboard Unavailable</div>
         <div class="card-content flex">
           ESPHome Web requires a browser that supports WebSerial. Please open
-          this website on your desktop using Google Chrome or Microsoft Edge.
+          this website on your desktop using Firefox, Google Chrome or Microsoft
+          Edge.
         </div>
       </esphome-card>
     `;


### PR DESCRIPTION
Firefox now supports WebSerial, so include it as the first recommended browser alongside Chrome and Edge.

https://claude.ai/code/session_01ExQBugKtkjvSa8VX84hg6V