### PR TITLE
Show "Via the network" instead of "Wirelessly" in logs dialog for Ethernet devices

### DIFF
--- a/src/logs-target/logs-target-dialog.ts
+++ b/src/logs-target/logs-target-dialog.ts
@@ -7,6 +7,7 @@ import "../components/remote-process";
 import "../components/process-dialog";
 import { openLogsDialog } from "../logs";
 import { getSerialPorts, ServerSerialPort } from "../api/serial-ports";
+import { getConfiguration } from "../api/configuration";
 import { allowsWebSerial, metaChevronRight, supportsWebSerial } from "../const";
 import { openLogsWebSerialDialog } from "../logs-webserial";
 import { esphomeDialogStyles, esphomeSvgStyles } from "../styles";
@@ -16,6 +17,8 @@ const ESPHOME_WEB_URL = "https://web.esphome.io/?dashboard_logs";
 @customElement("esphome-logs-target-dialog")
 class ESPHomeLogsTargetDialog extends LitElement {
   @property() public configuration!: string;
+
+  @state() private _ethernet = false;
 
   @state() private _ports?: ServerSerialPort[];
 
@@ -36,7 +39,7 @@ class ESPHomeLogsTargetDialog extends LitElement {
           .port=${"OTA"}
           @click=${this._pickPort}
         >
-          <span>Wirelessly</span>
+          <span>${this._ethernet ? "Via the network" : "Wirelessly"}</span>
           <span slot="secondary">Requires the device to be online</span>
           ${metaChevronRight}
         </mwc-list-item>
@@ -161,12 +164,15 @@ class ESPHomeLogsTargetDialog extends LitElement {
     super.firstUpdated(changedProperties);
     getSerialPorts().then((ports) => {
       if (ports.length === 0 && !supportsWebSerial) {
-        // Automatically pick wireless option if no other options available
+        // Automatically pick the network option if no other options available
         this._handleClose();
         openLogsDialog(this.configuration, "OTA");
       } else {
         this._ports = ports;
       }
+    });
+    getConfiguration(this.configuration).then((config) => {
+      this._ethernet = config.loaded_integrations.includes("ethernet");
     });
   }
 


### PR DESCRIPTION
## What does this implement/fix?

The "How to get the logs for your device?" dialog always labels the OTA option **"Wirelessly"**. For devices that are connected via Ethernet this is misleading — the connection is wired, there is nothing wireless about it.

The install dialog already handles this case: `install-choose-dialog.ts` shows **"Via the network"** when the configuration uses the `ethernet` component. This PR applies the exact same logic to the logs target dialog:

- Fetch the configuration in `firstUpdated()` and set `_ethernet` based on `loaded_integrations.includes("ethernet")`
- Show "Via the network" instead of "Wirelessly" when the device uses Ethernet
- Reword the auto-pick comment from "wireless option" to "network option" to match

WiFi-based devices keep the existing "Wirelessly" label, identical to the install dialog behaviour.