### PR TITLE
Add USB flash hand-off from ESPHome Device Builder via postMessage

### DIFF
--- a/src/install-web/index.ts
+++ b/src/install-web/index.ts
@@ -14,8 +14,13 @@ export const openInstallWebDialog = async (
   let port = params.port;
 
   if (port) {
-    // ESPLoader likes opening the port.
-    await port.close();
+    // ESPLoader likes opening the port; tolerate a port that isn't open yet
+    // (a caller may pass a freshly-requested, unopened port).
+    try {
+      await port.close();
+    } catch {
+      // not open / already closed
+    }
   } else {
     try {
       port = await navigator.serial.requestPort();

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -41,6 +41,17 @@ export class ESPHomeInstallWebDialog extends LitElement {
     // Callback when the dialog is closed. Note that if success is false,
     // some other dialog might be opened when the dialog is closed.
     onClose?: (success: boolean) => void;
+    // Mirror progress (0-100) and state to an embedder that shows the flash
+    // elsewhere (the postMessage hand-off from ESPHome Device Builder).
+    onProgress?: (pct: number) => void;
+    onStateChange?: (
+      state:
+        | "connecting_webserial"
+        | "prepare_installation"
+        | "installing"
+        | "done",
+      error?: string,
+    ) => void;
   };
 
   @property() public esploader!: ESPLoader;
@@ -56,6 +67,27 @@ export class ESPHomeInstallWebDialog extends LitElement {
   @state() private _error?: string | TemplateResult;
 
   private _platform?: SupportedPlatforms;
+
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+    if (
+      changedProps.has("_writeProgress") &&
+      this._writeProgress !== undefined
+    ) {
+      this.params.onProgress?.(this._writeProgress);
+    }
+    if (changedProps.has("_state")) {
+      // Preserve the error signal even when _error is a TemplateResult, so an
+      // embedder mirroring "done" can't mistake a failure for success.
+      const error =
+        this._error === undefined
+          ? undefined
+          : typeof this._error === "string"
+            ? this._error
+            : "Installation failed";
+      this.params.onStateChange?.(this._state, error);
+    }
+  }
 
   protected render() {
     let heading;

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -209,7 +209,14 @@ export class ESPHomeInstallWebDialog extends LitElement {
 
   private async _handleInstall() {
     const esploader = this.esploader;
+    // Set once the flash succeeds: the post-flash reset re-enumerates the USB
+    // device (a native USB-Serial-JTAG chip drops and re-creates its port on
+    // boot), and that expected disconnect must not be reported as a failure.
+    let installed = false;
     esploader.transport.device.addEventListener("disconnect", async () => {
+      if (installed) {
+        return;
+      }
       this._state = "done";
       this._error = "Device disconnected";
       if (!this.params.port) {
@@ -273,6 +280,9 @@ export class ESPHomeInstallWebDialog extends LitElement {
         return;
       }
 
+      // The flash itself is done; the reset below intentionally re-enumerates
+      // the device, so stop treating a disconnect as a failure.
+      installed = true;
       // A bare RTS toggle leaves native USB-Serial-JTAG chips (S3/C3/...) in
       // download mode after writeFlash; pick a reset strategy that boots the app.
       await hardResetChip(

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -285,11 +285,17 @@ export class ESPHomeInstallWebDialog extends LitElement {
       installed = true;
       // A bare RTS toggle leaves native USB-Serial-JTAG chips (S3/C3/...) in
       // download mode after writeFlash; pick a reset strategy that boots the app.
-      await hardResetChip(
-        esploader,
-        esploader.transport,
-        esploader.transport.device,
-      );
+      // The write is already committed, so a reset that throws must not report
+      // the install as failed: log it and still mark done.
+      try {
+        await hardResetChip(
+          esploader,
+          esploader.transport,
+          esploader.transport.device,
+        );
+      } catch (err) {
+        console.error("Post-flash reset failed:", err);
+      }
       this._state = "done";
     } finally {
       console.log("Closing port");

--- a/src/install-web/install-web-dialog.ts
+++ b/src/install-web/install-web-dialog.ts
@@ -23,7 +23,7 @@ import {
 } from "../const";
 import { esphomeDialogStyles } from "../styles";
 import { sleep } from "../util/sleep";
-import { resetSerialDevice } from "../web-serial/reset-serial-device";
+import { hardResetChip } from "../web-serial/hard-reset";
 
 const OK_ICON = "🎉";
 const WARNING_ICON = "👀";
@@ -273,8 +273,13 @@ export class ESPHomeInstallWebDialog extends LitElement {
         return;
       }
 
-      await esploader.after();
-      await resetSerialDevice(esploader.transport);
+      // A bare RTS toggle leaves native USB-Serial-JTAG chips (S3/C3/...) in
+      // download mode after writeFlash; pick a reset strategy that boots the app.
+      await hardResetChip(
+        esploader,
+        esploader.transport,
+        esploader.transport.device,
+      );
       this._state = "done";
     } finally {
       console.log("Closing port");

--- a/src/web-serial/hard-reset.ts
+++ b/src/web-serial/hard-reset.ts
@@ -61,9 +61,12 @@ async function watchdogReset(
   try {
     await loader.writeReg(regs.wdtWProtect, RTC_CNTL_WDT_WKEY);
     await loader.writeReg(regs.wdtConfig1, 2000);
+    // config0 = 0xD0000102: enable (bit 31) | stage0 = reset-system (bits 28-30
+    // = 5) | clock prescaler (bit 8) | timeout-stage 2. >>> 0 keeps it an
+    // unsigned u32 (1 << 31 alone is negative in JS).
     await loader.writeReg(
       regs.wdtConfig0,
-      (1 << 31) | (5 << 28) | (1 << 8) | 2,
+      ((1 << 31) | (5 << 28) | (1 << 8) | 2) >>> 0,
     );
   } catch (err) {
     // A genuine transport error before the WDT was armed: don't claim success,

--- a/src/web-serial/hard-reset.ts
+++ b/src/web-serial/hard-reset.ts
@@ -1,0 +1,103 @@
+import { ESPLoader, Transport, UsbJtagSerialReset } from "esptool-js";
+import { sleep } from "../util/sleep";
+
+const ESPRESSIF_USB_VID = 0x303a;
+
+// RTC watchdog registers per chip (base + offsets), from esptool python.
+const WDT_RESET_CHIPS: Record<
+  string,
+  { wdtConfig0: number; wdtConfig1: number; wdtWProtect: number }
+> = {
+  "ESP32-S2": {
+    wdtConfig0: 0x3f408094,
+    wdtConfig1: 0x3f408098,
+    wdtWProtect: 0x3f4080ac,
+  },
+  "ESP32-S3": {
+    wdtConfig0: 0x60008098,
+    wdtConfig1: 0x6000809c,
+    wdtWProtect: 0x600080b0,
+  },
+  "ESP32-C2": {
+    wdtConfig0: 0x60008084,
+    wdtConfig1: 0x60008088,
+    wdtWProtect: 0x6000809c,
+  },
+  "ESP32-C3": {
+    wdtConfig0: 0x60008090,
+    wdtConfig1: 0x60008094,
+    wdtWProtect: 0x600080a8,
+  },
+};
+
+// Magic key that unlocks the RTC WDT write-protect register.
+const RTC_CNTL_WDT_WKEY = 0x50d83aa1;
+
+// Full chip reset via the RTC watchdog: the stub processes the writeReg
+// commands, the WDT fires, and the chip resets through ROM to the new firmware.
+// Works where a DTR/RTS reset doesn't reach the chip (native USB-Serial-JTAG,
+// CH9102F bridges). Returns false for chips without a safe WDT (C6 freezes;
+// classic ESP32 / ESP8266 have none).
+async function watchdogReset(
+  loader: ESPLoader,
+  transport: Transport,
+): Promise<boolean> {
+  const regs = loader.chip?.CHIP_NAME
+    ? WDT_RESET_CHIPS[loader.chip.CHIP_NAME]
+    : undefined;
+  if (!regs) {
+    return false;
+  }
+  // Release the boot-strap pin before the WDT fires so the chip boots from
+  // flash, not download mode.
+  try {
+    await transport.setDTR(false);
+    await transport.setRTS(false);
+  } catch {
+    // setSignals may fail; the WDT can still reset the chip.
+  }
+  // Sequence + magic value from esptool python's watchdog_reset(): unlock, set
+  // timeout, enable+arm, re-lock.
+  try {
+    await loader.writeReg(regs.wdtWProtect, RTC_CNTL_WDT_WKEY);
+    await loader.writeReg(regs.wdtConfig1, 2000);
+    await loader.writeReg(
+      regs.wdtConfig0,
+      (1 << 31) | (5 << 28) | (1 << 8) | 2,
+    );
+    await loader.writeReg(regs.wdtWProtect, 0);
+  } catch {
+    // A writeReg can race the reset firing; the WDT has already done its job.
+  }
+  await sleep(200);
+  return true;
+}
+
+// Boot a classic ESP32 / ESP8266 behind a UART bridge: pulse EN (RTS) low to
+// high with GPIO0 (DTR) released so the chip runs the app, not the bootloader.
+async function classicHardReset(transport: Transport): Promise<void> {
+  await transport.setDTR(false); // GPIO0 high -> boot from flash, not download
+  await transport.setRTS(true); // EN low (hold in reset)
+  await sleep(100);
+  await transport.setRTS(false); // EN high -> boot the app
+}
+
+// Reset the just-flashed chip into the app. esptool-js's after("hard_reset")
+// (and a bare RTS toggle) leaves a native USB-Serial-JTAG chip in download mode
+// after writeFlash, so the firmware never boots; pick a real strategy instead.
+// Mirrors the device-builder flasher and the device-builder-frontend web-serial
+// reset.
+export async function hardResetChip(
+  loader: ESPLoader,
+  transport: Transport,
+  port: SerialPort,
+): Promise<void> {
+  if (await watchdogReset(loader, transport)) {
+    return;
+  }
+  if (port.getInfo().usbVendorId === ESPRESSIF_USB_VID) {
+    await new UsbJtagSerialReset(transport).reset();
+  } else {
+    await classicHardReset(transport);
+  }
+}

--- a/src/web-serial/hard-reset.ts
+++ b/src/web-serial/hard-reset.ts
@@ -65,9 +65,18 @@ async function watchdogReset(
       regs.wdtConfig0,
       (1 << 31) | (5 << 28) | (1 << 8) | 2,
     );
+  } catch (err) {
+    // A genuine transport error before the WDT was armed: don't claim success,
+    // so the caller falls through to the VID-based reset instead of leaving a
+    // native-USB chip stuck in download mode.
+    console.error("Watchdog reset failed to arm:", err);
+    return false;
+  }
+  // The re-lock can race the reset firing (the WDT has already done its job).
+  try {
     await loader.writeReg(regs.wdtWProtect, 0);
   } catch {
-    // A writeReg can race the reset firing; the WDT has already done its job.
+    // raced by the reset; ignore
   }
   await sleep(200);
   return true;

--- a/web.esphome.io/src/dashboard/esp-device-card.ts
+++ b/web.esphome.io/src/dashboard/esp-device-card.ts
@@ -3,7 +3,7 @@ import "@material/mwc-button";
 import "@material/mwc-icon-button";
 import type { ActionDetail } from "@material/mwc-list";
 import { LitElement, html, css, PropertyValues } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import "../../../src/components/esphome-svg-icon";
 import "../../../src/components/esphome-card";
 import "../../../src/components/esphome-button-menu";
@@ -26,11 +26,14 @@ import { mdiLinkOff, mdiWifiCog } from "@mdi/js";
 @customElement("ew-esp-device-card")
 class EWESPDeviceCard extends LitElement {
   public port!: SerialPort;
+  // Optional friendly name (e.g. from a Device Builder hand-off); falls back to
+  // the generic label for the standard connect flow.
+  @property() public name?: string;
 
   protected render() {
     return html`
       <esphome-card status="CONNECTED" no-status-bar>
-        <div class="card-header">ESP Device</div>
+        <div class="card-header">${this.name || "ESP Device"}</div>
         <div class="card-content flex"></div>
 
         <div class="card-actions">

--- a/web.esphome.io/src/dashboard/esp-device-card.ts
+++ b/web.esphome.io/src/dashboard/esp-device-card.ts
@@ -3,7 +3,7 @@ import "@material/mwc-button";
 import "@material/mwc-icon-button";
 import type { ActionDetail } from "@material/mwc-list";
 import { LitElement, html, css, PropertyValues } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement } from "lit/decorators.js";
 import "../../../src/components/esphome-svg-icon";
 import "../../../src/components/esphome-card";
 import "../../../src/components/esphome-button-menu";
@@ -26,14 +26,11 @@ import { mdiLinkOff, mdiWifiCog } from "@mdi/js";
 @customElement("ew-esp-device-card")
 class EWESPDeviceCard extends LitElement {
   public port!: SerialPort;
-  // Optional friendly name (e.g. from a Device Builder hand-off); falls back to
-  // the generic label for the standard connect flow.
-  @property() public name?: string;
 
   protected render() {
     return html`
       <esphome-card status="CONNECTED" no-status-bar>
-        <div class="card-header">${this.name || "ESP Device"}</div>
+        <div class="card-header">ESP Device</div>
         <div class="card-content flex"></div>
 
         <div class="card-actions">

--- a/web.esphome.io/src/dashboard/ew-dashboard.ts
+++ b/web.esphome.io/src/dashboard/ew-dashboard.ts
@@ -112,15 +112,22 @@ class EWDashboard extends LitElement {
     `;
   }
 
-  protected firstUpdated(changedProps: PropertyValues): void {
-    super.firstUpdated(changedProps);
-    // Only enter flash mode for a real hand-off (opened by Device Builder). A
-    // stale #nonce bookmark without an opener falls through to the dashboard.
+  connectedCallback(): void {
+    super.connectedCallback();
+    // Decide flash mode before the first render to avoid a one-frame flash of
+    // the normal dashboard. Only a real hand-off (opened by Device Builder) qualifies;
+    // a stale #nonce bookmark without an opener falls through to the dashboard.
     if (
       window.opener &&
       new URLSearchParams(location.hash.slice(1)).get("nonce")
     ) {
       this.flashMode = true;
+    }
+  }
+
+  protected firstUpdated(changedProps: PropertyValues): void {
+    super.firstUpdated(changedProps);
+    if (this.flashMode) {
       return;
     }
     const params = new URLSearchParams(location.search);

--- a/web.esphome.io/src/dashboard/ew-dashboard.ts
+++ b/web.esphome.io/src/dashboard/ew-dashboard.ts
@@ -4,6 +4,7 @@ import "@material/mwc-button";
 import "./unsupported-card";
 import "./esp-connect-card";
 import "./pico-connect-card";
+import "./ew-web-flash";
 import { supportsWebSerial } from "../../../src/const";
 import { ARROW, ARROW_RIGHT } from "./arrow";
 import { esphomeSvgStyles } from "../../../src/styles";
@@ -11,8 +12,21 @@ import { esphomeSvgStyles } from "../../../src/styles";
 @customElement("ew-dashboard")
 class EWDashboard extends LitElement {
   @state() private pico = false;
+  // Set when opened by ESPHome Device Builder to receive firmware over
+  // postMessage and flash it over USB (the add-on is plain http, so it can't run
+  // Web Serial itself); the nonce in the hash is the hand-off marker.
+  @state() private flashMode = false;
 
   protected render() {
+    if (this.flashMode) {
+      return html`
+        <div class="container">
+          ${!supportsWebSerial
+            ? html`<ew-unsupported-card></ew-unsupported-card>`
+            : html`<ew-web-flash></ew-web-flash>`}
+        </div>
+      `;
+    }
     return html`
       <div class="container">
         ${!supportsWebSerial
@@ -100,6 +114,10 @@ class EWDashboard extends LitElement {
 
   protected firstUpdated(changedProps: PropertyValues): void {
     super.firstUpdated(changedProps);
+    if (new URLSearchParams(location.hash.slice(1)).get("nonce")) {
+      this.flashMode = true;
+      return;
+    }
     const params = new URLSearchParams(location.search);
 
     for (const key of params.keys()) {

--- a/web.esphome.io/src/dashboard/ew-dashboard.ts
+++ b/web.esphome.io/src/dashboard/ew-dashboard.ts
@@ -114,7 +114,12 @@ class EWDashboard extends LitElement {
 
   protected firstUpdated(changedProps: PropertyValues): void {
     super.firstUpdated(changedProps);
-    if (new URLSearchParams(location.hash.slice(1)).get("nonce")) {
+    // Only enter flash mode for a real hand-off (opened by Device Builder). A
+    // stale #nonce bookmark without an opener falls through to the dashboard.
+    if (
+      window.opener &&
+      new URLSearchParams(location.hash.slice(1)).get("nonce")
+    ) {
       this.flashMode = true;
       return;
     }

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -112,6 +112,7 @@ class EWWebFlash extends LitElement {
       return this._port
         ? html`<ew-esp-device-card
             .port=${this._port}
+            .name=${this._deviceName}
             @close=${this._onCardClose}
           ></ew-esp-device-card>`
         : html`<esphome-card status="DONE">

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -70,8 +70,9 @@ class EWWebFlash extends LitElement {
 
   private _nonce = "";
   private _opener: Window | null = null;
-  // Stays '*' until the first valid inbound frame reveals the opener origin; no
-  // outbound frame carries the nonce, so the pre-handoff broadcast leaks nothing.
+  // Seeded from the 'origin' hash param when the opener passes it, otherwise '*'
+  // until the first valid inbound frame reveals the opener origin. No outbound
+  // frame carries the nonce, so even the '*' broadcast leaks nothing.
   private _targetOrigin = "*";
   private _files: FileToFlash[] | null = null;
   private _erase = true;

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -247,59 +247,66 @@ class EWWebFlash extends LitElement {
     // (logs are a separate fresh connect), mirroring the device-builder flasher.
     // "Erasing" until the first write progress arrives, then "Installing".
     let writing = false;
-    await openInstallWebDialog({
-      erase: this._erase,
-      filesCallback: async () => files,
-      // Mirror progress and the granular phase so the dashboard's install view
-      // tracks this tab instead of showing a stale phase.
-      onProgress: (pct) => {
-        this._post({ type: MSG_PROGRESS, pct });
-        if (!writing) {
-          writing = true;
-          this._post({
-            type: MSG_STATE,
-            state: "installing",
-            detail: "Installing over USB…",
-          });
-        }
-      },
-      onStateChange: (state, error) => {
-        if (state === "done") {
-          this._post({
-            type: MSG_STATE,
-            state: error ? "error" : "done",
-            detail: error ?? "",
-          });
-          return;
-        }
-        // Map install-web's phases to the mirror; onProgress flips to
-        // "Installing" once the first write lands.
-        if (state === "installing") {
-          this._post({
-            type: MSG_STATE,
-            state: "installing",
-            detail: "Erasing…",
-          });
-        } else if (state === "prepare_installation") {
-          this._post({
-            type: MSG_STATE,
-            state: "installing",
-            detail: "Preparing…",
-          });
-        } else {
-          this._post({
-            type: MSG_STATE,
-            state: "connecting",
-            detail: "Connecting to device…",
-          });
-        }
-      },
-      onClose: (success) => {
-        this._busy = false;
-        // Failed: stay on the card so the user can retry. Succeeded: done.
-        this._status = success ? "done" : "ready";
-      },
-    });
+    try {
+      await openInstallWebDialog({
+        erase: this._erase,
+        filesCallback: async () => files,
+        // Mirror progress and the granular phase so the dashboard's install view
+        // tracks this tab instead of showing a stale phase.
+        onProgress: (pct) => {
+          this._post({ type: MSG_PROGRESS, pct });
+          if (!writing) {
+            writing = true;
+            this._post({
+              type: MSG_STATE,
+              state: "installing",
+              detail: "Installing over USB…",
+            });
+          }
+        },
+        onStateChange: (state, error) => {
+          if (state === "done") {
+            this._post({
+              type: MSG_STATE,
+              state: error ? "error" : "done",
+              detail: error ?? "",
+            });
+            return;
+          }
+          // Map install-web's phases to the mirror; onProgress flips to
+          // "Installing" once the first write lands.
+          if (state === "installing") {
+            this._post({
+              type: MSG_STATE,
+              state: "installing",
+              detail: "Erasing…",
+            });
+          } else if (state === "prepare_installation") {
+            this._post({
+              type: MSG_STATE,
+              state: "installing",
+              detail: "Preparing…",
+            });
+          } else {
+            this._post({
+              type: MSG_STATE,
+              state: "connecting",
+              detail: "Connecting to device…",
+            });
+          }
+        },
+        onClose: (success) => {
+          this._busy = false;
+          // Failed: stay on the card so the user can retry. Succeeded: done.
+          this._status = success ? "done" : "ready";
+        },
+      });
+    } catch (err) {
+      // A throw before onClose (e.g. failing to open the dialog) would otherwise
+      // leave the button disabled forever; re-enable so the user can retry.
+      console.error("Failed to open the USB installer:", err);
+      this._busy = false;
+    }
   };
 
   private _fail(detail: string): void {

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -218,27 +218,38 @@ class EWWebFlash extends LitElement {
     if (!this._files || this._busy) return;
     this._busy = true;
     const files = this._files;
-    // Open the port ourselves and pass it in, so install-web keeps it open after
-    // the flash; that lets us drop straight onto the device card.
+    // Pick the port but don't open it; install-web opens it via the ESPLoader
+    // (which surfaces the "hold BOOT" guidance on a chip-init failure) and
+    // reopens it after a successful flash so we can show the device card. This
+    // mirrors the device-builder flasher, which never pre-opens the port.
     let port: SerialPort;
     try {
       port = await navigator.serial.requestPort();
-      await port.open({ baudRate: 115200, bufferSize: 8192 });
-    } catch (err) {
+    } catch {
+      // Picker dismissed or failed; stay on the ready card so the user can retry.
       this._busy = false;
-      if ((err as DOMException)?.name !== "NotFoundError") {
-        this._fail(`Could not open the serial port: ${(err as Error).message}`);
-      }
       return;
     }
     this._port = port;
+    // "Erasing" until the first write progress arrives, then "Installing".
+    let writing = false;
     await openInstallWebDialog({
       port,
       erase: this._erase,
       filesCallback: async () => files,
-      // Mirror progress and state back to the dashboard so its own install view
-      // tracks this tab.
-      onProgress: (pct) => this._post({ type: MSG_PROGRESS, pct }),
+      // Mirror progress and the granular phase so the dashboard's install view
+      // tracks this tab instead of showing a stale phase.
+      onProgress: (pct) => {
+        this._post({ type: MSG_PROGRESS, pct });
+        if (!writing) {
+          writing = true;
+          this._post({
+            type: MSG_STATE,
+            state: "installing",
+            detail: "Installing over USB…",
+          });
+        }
+      },
       onStateChange: (state, error) => {
         if (state === "done") {
           this._post({
@@ -252,7 +263,7 @@ class EWWebFlash extends LitElement {
         this._post({
           type: MSG_STATE,
           state: installing ? "installing" : "connecting",
-          detail: installing ? "Installing over USB…" : "Connecting to device…",
+          detail: installing ? "Erasing…" : "Connecting to device…",
         });
       },
       onClose: (success) => {

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -174,11 +174,18 @@ class EWWebFlash extends LitElement {
   private _post(message: object): void {
     try {
       this._opener?.postMessage(message, this._targetOrigin);
-    } catch {
-      // A malformed origin from the hash would throw; broadcast instead so the
-      // repeating ready announcements don't wedge the handoff.
+    } catch (err) {
+      // A malformed origin from the hash makes postMessage throw; fall back to
+      // '*' so the ready announcements keep flowing (no nonce travels outbound,
+      // so the broader audience leaks nothing). Log rather than swallow so an
+      // unrelated failure stays visible.
+      console.error("postMessage failed; falling back to '*':", err);
       this._targetOrigin = "*";
-      this._opener?.postMessage(message, "*");
+      try {
+        this._opener?.postMessage(message, "*");
+      } catch (err2) {
+        console.error("postMessage failed after origin fallback:", err2);
+      }
     }
   }
 

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -1,0 +1,225 @@
+import { LitElement, html, css } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import "@material/mwc-button";
+import {
+  openInstallWebDialog,
+  preloadInstallWebDialog,
+} from "../../../src/install-web";
+import type { FileToFlash } from "../../../src/web-serial/flash";
+import { esphomeDialogStyles } from "../../../src/styles";
+
+// Message contract shared with the ESPHome Device Builder dashboard (the opener,
+// on any http/https origin). The opener origin is unknown, so authentication is
+// the one-time nonce plus an "is this my opener" source check, never an origin
+// allowlist. The nonce travels one way only (opener to here); no outbound frame
+// echoes it. Mirrors flasher/src/protocol.ts in the device-builder repo.
+const PROTOCOL_VERSION = 1;
+const MSG_READY = "esphome-web-flash:ready";
+const MSG_FIRMWARE = "esphome-web-flash:firmware";
+const MSG_STATE = "esphome-web-flash:state";
+
+interface FirmwarePart {
+  address: number;
+  data: ArrayBuffer;
+}
+
+// install-web wants each image as a binary string (the same shape FileReader's
+// readAsBinaryString produces); convert in chunks so a ~1MB factory image
+// doesn't blow the argument limit of String.fromCharCode.
+function bufferToBinaryString(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const CHUNK = 0x8000;
+  let result = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    result += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return result;
+}
+
+@customElement("ew-web-flash")
+class EWWebFlash extends LitElement {
+  @state() private _status: "waiting" | "ready" | "error" = "waiting";
+  @state() private _name = "";
+  @state() private _detail = "";
+  @state() private _busy = false;
+
+  private _nonce = "";
+  private _opener: Window | null = null;
+  // Stays '*' until the first valid inbound frame reveals the opener origin; no
+  // outbound frame carries the nonce, so the pre-handoff broadcast leaks nothing.
+  private _targetOrigin = "*";
+  private _files: FileToFlash[] | null = null;
+  private _erase = true;
+  private _readyTimer?: number;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    const params = new URLSearchParams(location.hash.slice(1));
+    this._nonce = params.get("nonce") ?? "";
+    this._targetOrigin = params.get("origin") || "*";
+    this._opener = window.opener;
+    if (!this._opener || !this._nonce) {
+      this._status = "error";
+      this._detail =
+        "Open this page from ESPHome Device Builder to flash a device over USB.";
+      return;
+    }
+    window.addEventListener("message", this._onMessage);
+    preloadInstallWebDialog();
+    // Re-announce until firmware arrives: a single 'ready' can race the opener
+    // attaching its listener after window.open().
+    this._sendReady();
+    let waited = 0;
+    this._readyTimer = window.setInterval(() => {
+      waited += 500;
+      if (this._files || waited >= 10000) {
+        this._stopReady();
+        return;
+      }
+      this._sendReady();
+    }, 500);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener("message", this._onMessage);
+    this._stopReady();
+  }
+
+  protected render() {
+    return html`
+      <div class="card">
+        <h2>Install over USB</h2>
+        ${this._status === "error"
+          ? html`<p class="error">${this._detail}</p>`
+          : this._status === "waiting"
+            ? html`<p>
+                Waiting for firmware from ESPHome Device Builder&hellip;
+              </p>`
+            : html`
+                <p>
+                  Firmware
+                  received${this._name
+                    ? html` (<code>${this._name}</code>)`
+                    : ""}.
+                  Plug your device into this computer over USB, then connect and
+                  install.
+                </p>
+                <mwc-button
+                  raised
+                  label="Connect & install"
+                  .disabled=${this._busy}
+                  @click=${this._install}
+                ></mwc-button>
+              `}
+      </div>
+    `;
+  }
+
+  private _stopReady(): void {
+    if (this._readyTimer !== undefined) {
+      clearInterval(this._readyTimer);
+      this._readyTimer = undefined;
+    }
+  }
+
+  private _post(message: object): void {
+    this._opener?.postMessage(message, this._targetOrigin);
+  }
+
+  private _sendReady(): void {
+    this._post({ type: MSG_READY, version: PROTOCOL_VERSION });
+  }
+
+  private _onMessage = (ev: MessageEvent): void => {
+    // Only the window that opened us, and only with the matching nonce.
+    if (!this._opener || ev.source !== this._opener) return;
+    const data = ev.data;
+    if (!data || data.type !== MSG_FIRMWARE || data.nonce !== this._nonce)
+      return;
+    if (this._files) return; // already handed off
+    if (!Array.isArray(data.parts) || data.parts.length === 0) {
+      this._fail("Received a malformed firmware payload.");
+      return;
+    }
+    if (this._targetOrigin === "*" && ev.origin && ev.origin !== "null") {
+      this._targetOrigin = ev.origin;
+    }
+    this._stopReady();
+    try {
+      this._files = (data.parts as FirmwarePart[]).map((part) => ({
+        data: bufferToBinaryString(part.data),
+        address: part.address,
+      }));
+    } catch {
+      this._fail("Could not read the firmware payload.");
+      return;
+    }
+    this._erase = data.erase ?? true;
+    this._name = typeof data.name === "string" ? data.name : "";
+    this._status = "ready";
+  };
+
+  private _install = async (): Promise<void> => {
+    if (!this._files || this._busy) return;
+    this._busy = true;
+    const files = this._files;
+    let opened = false;
+    await openInstallWebDialog(
+      {
+        erase: this._erase,
+        filesCallback: async () => files,
+        onClose: (success) => {
+          this._busy = false;
+          this._post({
+            type: MSG_STATE,
+            state: success ? "done" : "error",
+            detail: success ? "" : "Installation did not complete.",
+          });
+        },
+      },
+      () => {
+        opened = true;
+      },
+    );
+    // Port picker dismissed or failed before the dialog opened: re-enable so the
+    // user can try again (install-web's own no-port dialog also offers a retry).
+    if (!opened) this._busy = false;
+  };
+
+  private _fail(detail: string): void {
+    this._status = "error";
+    this._detail = detail;
+  }
+
+  static styles = [
+    esphomeDialogStyles,
+    css`
+      .card {
+        margin: 40px auto;
+        max-width: 450px;
+        padding: 24px;
+        border-radius: 12px;
+        background: var(--card-background-color, #fff);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+        text-align: center;
+        color: var(--primary-text-color);
+      }
+      h2 {
+        margin-top: 0;
+      }
+      code {
+        word-break: break-all;
+      }
+      .error {
+        color: var(--alert-error-color);
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ew-web-flash": EWWebFlash;
+  }
+}

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -1,12 +1,14 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "@material/mwc-button";
+import "../../../src/components/esphome-card";
+import "./esp-device-card";
 import {
   openInstallWebDialog,
   preloadInstallWebDialog,
 } from "../../../src/install-web";
 import type { FileToFlash } from "../../../src/web-serial/flash";
-import { esphomeDialogStyles } from "../../../src/styles";
+import { esphomeCardStyles } from "../../../src/styles";
 
 // Message contract shared with the ESPHome Device Builder dashboard (the opener,
 // on any http/https origin). The opener origin is unknown, so authentication is
@@ -17,31 +19,48 @@ const PROTOCOL_VERSION = 1;
 const MSG_READY = "esphome-web-flash:ready";
 const MSG_FIRMWARE = "esphome-web-flash:firmware";
 const MSG_STATE = "esphome-web-flash:state";
+const MSG_PROGRESS = "esphome-web-flash:progress";
 
 interface FirmwarePart {
   address: number;
   data: ArrayBuffer;
 }
 
-// install-web wants each image as a binary string (the same shape FileReader's
-// readAsBinaryString produces); convert in chunks so a ~1MB factory image
-// doesn't blow the argument limit of String.fromCharCode.
-function bufferToBinaryString(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  const CHUNK = 0x8000;
-  let result = "";
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    result += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-  }
-  return result;
+// install-web wants each image as a binary string (the byte-for-byte shape
+// FileReader's readAsBinaryString produces); latin1 maps each byte 1:1 to the
+// same code unit, in one native call.
+const toBinaryString = (buffer: ArrayBuffer): string =>
+  new TextDecoder("latin1").decode(buffer);
+
+// Validate the firmware payload before trusting its shape: each part must have a
+// non-negative integer address and ArrayBuffer data. Mirrors isFlashParts in the
+// device-builder flasher.
+function isFlashParts(parts: unknown): parts is FirmwarePart[] {
+  return (
+    Array.isArray(parts) &&
+    parts.length > 0 &&
+    parts.every(
+      (p) =>
+        p &&
+        typeof p === "object" &&
+        typeof p.address === "number" &&
+        Number.isInteger(p.address) &&
+        p.address >= 0 &&
+        p.data instanceof ArrayBuffer,
+    )
+  );
 }
 
 @customElement("ew-web-flash")
 class EWWebFlash extends LitElement {
-  @state() private _status: "waiting" | "ready" | "error" = "waiting";
+  @state() private _status: "waiting" | "ready" | "done" | "error" = "waiting";
   @state() private _name = "";
+  @state() private _deviceName = "";
   @state() private _detail = "";
   @state() private _busy = false;
+  // The connected port, kept open after a successful flash so the user lands on
+  // the standard device card (logs, prepare for first use).
+  @state() private _port: SerialPort | null = null;
 
   private _nonce = "";
   private _opener: Window | null = null;
@@ -87,32 +106,54 @@ class EWWebFlash extends LitElement {
   }
 
   protected render() {
+    // After a successful flash, hand the kept-open port to the standard device
+    // card so the user can check logs or prepare the device for first use.
+    if (this._status === "done") {
+      return this._port
+        ? html`<ew-esp-device-card
+            .port=${this._port}
+            @close=${this._onCardClose}
+          ></ew-esp-device-card>`
+        : html`<esphome-card status="DONE">
+            <div class="card-header">Install over USB</div>
+            <div class="card-content">Installed. You can close this tab.</div>
+          </esphome-card>`;
+    }
     return html`
-      <div class="card">
-        <h2>Install over USB</h2>
-        ${this._status === "error"
-          ? html`<p class="error">${this._detail}</p>`
-          : this._status === "waiting"
-            ? html`<p>
-                Waiting for firmware from ESPHome Device Builder&hellip;
-              </p>`
-            : html`
-                <p>
-                  Firmware
+      <esphome-card
+        status=${this._status === "ready"
+          ? "READY"
+          : this._status === "error"
+            ? "ERROR"
+            : "WAITING"}
+      >
+        <div class="card-header">
+          ${this._deviceName
+            ? html`Install ${this._deviceName} over USB`
+            : "Install over USB"}
+        </div>
+        <div class="card-content">
+          ${this._status === "error"
+            ? html`<span class="error">${this._detail}</span>`
+            : this._status === "waiting"
+              ? html`Waiting for firmware from ESPHome Device Builder&hellip;`
+              : html`Firmware for
+                  <b>${this._deviceName || "your device"}</b>
                   received${this._name
                     ? html` (<code>${this._name}</code>)`
                     : ""}.
-                  Plug your device into this computer over USB, then connect and
-                  install.
-                </p>
-                <mwc-button
-                  raised
-                  label="Connect & install"
-                  .disabled=${this._busy}
-                  @click=${this._install}
-                ></mwc-button>
-              `}
-      </div>
+                  Plug it into this computer over USB, then connect and install.`}
+        </div>
+        ${this._status === "ready"
+          ? html`<div class="card-actions">
+              <mwc-button
+                label="Connect & install"
+                .disabled=${this._busy}
+                @click=${this._install}
+              ></mwc-button>
+            </div>`
+          : nothing}
+      </esphome-card>
     `;
   }
 
@@ -124,7 +165,14 @@ class EWWebFlash extends LitElement {
   }
 
   private _post(message: object): void {
-    this._opener?.postMessage(message, this._targetOrigin);
+    try {
+      this._opener?.postMessage(message, this._targetOrigin);
+    } catch {
+      // A malformed origin from the hash would throw; broadcast instead so the
+      // repeating ready announcements don't wedge the handoff.
+      this._targetOrigin = "*";
+      this._opener?.postMessage(message, "*");
+    }
   }
 
   private _sendReady(): void {
@@ -138,7 +186,8 @@ class EWWebFlash extends LitElement {
     if (!data || data.type !== MSG_FIRMWARE || data.nonce !== this._nonce)
       return;
     if (this._files) return; // already handed off
-    if (!Array.isArray(data.parts) || data.parts.length === 0) {
+    const parts = data.parts;
+    if (!isFlashParts(parts)) {
       this._fail("Received a malformed firmware payload.");
       return;
     }
@@ -147,16 +196,20 @@ class EWWebFlash extends LitElement {
     }
     this._stopReady();
     try {
-      this._files = (data.parts as FirmwarePart[]).map((part) => ({
-        data: bufferToBinaryString(part.data),
+      this._files = parts.map((part) => ({
+        data: toBinaryString(part.data),
         address: part.address,
       }));
     } catch {
       this._fail("Could not read the firmware payload.");
       return;
     }
-    this._erase = data.erase ?? true;
+    this._erase = data.erase !== false;
     this._name = typeof data.name === "string" ? data.name : "";
+    this._deviceName =
+      typeof data.deviceName === "string" ? data.deviceName : "";
+    // Identify the window in the browser tab so multiple flashes don't blur.
+    if (this._deviceName) document.title = `Install ${this._deviceName}`;
     this._status = "ready";
   };
 
@@ -164,49 +217,75 @@ class EWWebFlash extends LitElement {
     if (!this._files || this._busy) return;
     this._busy = true;
     const files = this._files;
-    let opened = false;
-    await openInstallWebDialog(
-      {
-        erase: this._erase,
-        filesCallback: async () => files,
-        onClose: (success) => {
-          this._busy = false;
+    // Open the port ourselves and pass it in, so install-web keeps it open after
+    // the flash; that lets us drop straight onto the device card.
+    let port: SerialPort;
+    try {
+      port = await navigator.serial.requestPort();
+      await port.open({ baudRate: 115200, bufferSize: 8192 });
+    } catch (err) {
+      this._busy = false;
+      if ((err as DOMException)?.name !== "NotFoundError") {
+        this._fail(`Could not open the serial port: ${(err as Error).message}`);
+      }
+      return;
+    }
+    this._port = port;
+    await openInstallWebDialog({
+      port,
+      erase: this._erase,
+      filesCallback: async () => files,
+      // Mirror progress and state back to the dashboard so its own install view
+      // tracks this tab.
+      onProgress: (pct) => this._post({ type: MSG_PROGRESS, pct }),
+      onStateChange: (state, error) => {
+        if (state === "done") {
           this._post({
             type: MSG_STATE,
-            state: success ? "done" : "error",
-            detail: success ? "" : "Installation did not complete.",
+            state: error ? "error" : "done",
+            detail: error ?? "",
           });
-        },
+          return;
+        }
+        const installing = state === "installing";
+        this._post({
+          type: MSG_STATE,
+          state: installing ? "installing" : "connecting",
+          detail: installing ? "Installing over USB…" : "Connecting to device…",
+        });
       },
-      () => {
-        opened = true;
+      onClose: (success) => {
+        this._busy = false;
+        // Success leaves the port open; show the device card. On failure stay on
+        // the install card so the user can retry.
+        this._status = success ? "done" : "ready";
       },
-    );
-    // Port picker dismissed or failed before the dialog opened: re-enable so the
-    // user can try again (install-web's own no-port dialog also offers a retry).
-    if (!opened) this._busy = false;
+    });
+  };
+
+  private _onCardClose = (): void => {
+    this._port = null;
   };
 
   private _fail(detail: string): void {
+    this._stopReady(); // stop announcing ready once we're wedged
     this._status = "error";
     this._detail = detail;
   }
 
   static styles = [
-    esphomeDialogStyles,
+    esphomeCardStyles,
     css`
-      .card {
-        margin: 40px auto;
+      :host {
+        display: block;
         max-width: 450px;
-        padding: 24px;
-        border-radius: 12px;
-        background: var(--card-background-color, #fff);
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-        text-align: center;
-        color: var(--primary-text-color);
+        margin: 40px auto;
       }
-      h2 {
-        margin-top: 0;
+      esphome-card {
+        --status-color: var(--alert-warning-color);
+      }
+      .card-actions mwc-button {
+        --mdc-theme-primary: var(--alert-warning-color);
       }
       code {
         word-break: break-all;

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -272,12 +272,27 @@ class EWWebFlash extends LitElement {
           });
           return;
         }
-        const installing = state === "installing";
-        this._post({
-          type: MSG_STATE,
-          state: installing ? "installing" : "connecting",
-          detail: installing ? "Erasing…" : "Connecting to device…",
-        });
+        // Map install-web's phases to the mirror; onProgress flips to
+        // "Installing" once the first write lands.
+        if (state === "installing") {
+          this._post({
+            type: MSG_STATE,
+            state: "installing",
+            detail: "Erasing…",
+          });
+        } else if (state === "prepare_installation") {
+          this._post({
+            type: MSG_STATE,
+            state: "installing",
+            detail: "Preparing…",
+          });
+        } else {
+          this._post({
+            type: MSG_STATE,
+            state: "connecting",
+            detail: "Connecting to device…",
+          });
+        }
       },
       onClose: (success) => {
         this._busy = false;

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -57,9 +57,6 @@ class EWWebFlash extends LitElement {
   @state() private _deviceName = "";
   @state() private _detail = "";
   @state() private _busy = false;
-  // The connected port, kept open after a successful flash so the user lands on
-  // the standard device card (logs, prepare for first use).
-  @state() private _port: SerialPort | null = null;
 
   private _nonce = "";
   private _opener: Window | null = null;
@@ -216,23 +213,14 @@ class EWWebFlash extends LitElement {
     if (!this._files || this._busy) return;
     this._busy = true;
     const files = this._files;
-    // Pick the port but don't open it; install-web opens it via the ESPLoader
-    // (which surfaces the "hold BOOT" guidance on a chip-init failure) and
-    // reopens it after a successful flash so we can show the device card. This
-    // mirrors the device-builder flasher, which never pre-opens the port.
-    let port: SerialPort;
-    try {
-      port = await navigator.serial.requestPort();
-    } catch {
-      // Picker dismissed or failed; stay on the ready card so the user can retry.
-      this._busy = false;
-      return;
-    }
-    this._port = port;
+    // Let install-web own the port: it requests + opens it (surfacing the "hold
+    // BOOT" guidance on a chip-init failure) and, crucially, does NOT reopen it
+    // after the flash since we pass no port; reopening a native-USB port after
+    // the reset re-resets the chip into a boot loop. We don't need the port back
+    // (logs are a separate fresh connect), mirroring the device-builder flasher.
     // "Erasing" until the first write progress arrives, then "Installing".
     let writing = false;
     await openInstallWebDialog({
-      port,
       erase: this._erase,
       filesCallback: async () => files,
       // Mirror progress and the granular phase so the dashboard's install view
@@ -264,21 +252,10 @@ class EWWebFlash extends LitElement {
           detail: installing ? "Erasing…" : "Connecting to device…",
         });
       },
-      onClose: async (success) => {
+      onClose: (success) => {
         this._busy = false;
-        if (!success) {
-          this._status = "ready"; // failed: stay on the card so the user retries
-          return;
-        }
-        // Release the flash port so the rebooted device runs cleanly; the cached
-        // handle is unreliable after a native-USB re-enumeration anyway.
-        try {
-          await this._port?.close();
-        } catch {
-          // already closed / handle died on re-enumeration
-        }
-        this._port = null;
-        this._status = "done";
+        // Failed: stay on the card so the user can retry. Succeeded: done.
+        this._status = success ? "done" : "ready";
       },
     });
   };

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -120,8 +120,9 @@ class EWWebFlash extends LitElement {
             : "Install over USB"}
         </div>
         <div class="card-content">
-          Installed and rebooting. You can close this tab. To view logs, open
-          web.esphome.io and connect to the device.
+          Installed and rebooting. You can close this tab, or
+          <a href="${location.pathname}${location.search}">connect</a> to view
+          the device logs.
         </div>
       </esphome-card>`;
     }
@@ -292,6 +293,10 @@ class EWWebFlash extends LitElement {
       }
       code {
         word-break: break-all;
+      }
+      a {
+        color: inherit;
+        text-decoration: underline;
       }
       .error {
         color: var(--alert-error-color);

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -26,10 +26,20 @@ interface FirmwarePart {
 }
 
 // install-web wants each image as a binary string (the byte-for-byte shape
-// FileReader's readAsBinaryString produces); latin1 maps each byte 1:1 to the
-// same code unit, in one native call.
-const toBinaryString = (buffer: ArrayBuffer): string =>
-  new TextDecoder("latin1").decode(buffer);
+// FileReader's readAsBinaryString produces): each byte maps to the code unit of
+// the same value. Built in chunks so a ~1MB image doesn't blow the argument
+// limit of String.fromCharCode. Do NOT use TextDecoder("latin1") here: per the
+// Encoding spec that label is windows-1252, which remaps 0x80-0x9F and corrupts
+// the firmware (checksum failure on boot).
+function toBinaryString(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const CHUNK = 0x8000;
+  let result = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    result += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return result;
+}
 
 // Validate the firmware payload before trusting its shape: each part must have a
 // non-negative integer address and ArrayBuffer data. Mirrors isFlashParts in the

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -98,8 +98,16 @@ class EWWebFlash extends LitElement {
     let waited = 0;
     this._readyTimer = window.setInterval(() => {
       waited += 500;
-      if (this._files || waited >= 10000) {
+      if (this._files) {
         this._stopReady();
+        return;
+      }
+      if (waited >= 10000) {
+        // Opener crashed, navigated away, or speaks a mismatched protocol; give
+        // the user a terminal state instead of an endless spinner.
+        this._fail(
+          "Didn't receive firmware. Return to ESPHome Device Builder and try the USB install again.",
+        );
         return;
       }
       this._sendReady();

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -313,6 +313,10 @@ class EWWebFlash extends LitElement {
     this._stopReady(); // stop announcing ready once we're wedged
     this._status = "error";
     this._detail = detail;
+    // Notify the opener so its install view doesn't hang waiting for state
+    // frames after a post-handoff failure (malformed payload / conversion). A
+    // no-op when there's no opener (the open-directly error case).
+    this._post({ type: MSG_STATE, state: "error", detail });
   }
 
   static styles = [

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -98,10 +98,6 @@ class EWWebFlash extends LitElement {
     let waited = 0;
     this._readyTimer = window.setInterval(() => {
       waited += 500;
-      if (this._files) {
-        this._stopReady();
-        return;
-      }
       if (waited >= 10000) {
         // Opener crashed, navigated away, or speaks a mismatched protocol; give
         // the user a terminal state instead of an endless spinner.

--- a/web.esphome.io/src/dashboard/ew-web-flash.ts
+++ b/web.esphome.io/src/dashboard/ew-web-flash.ts
@@ -2,7 +2,6 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "@material/mwc-button";
 import "../../../src/components/esphome-card";
-import "./esp-device-card";
 import {
   openInstallWebDialog,
   preloadInstallWebDialog,
@@ -106,19 +105,18 @@ class EWWebFlash extends LitElement {
   }
 
   protected render() {
-    // After a successful flash, hand the kept-open port to the standard device
-    // card so the user can check logs or prepare the device for first use.
     if (this._status === "done") {
-      return this._port
-        ? html`<ew-esp-device-card
-            .port=${this._port}
-            .name=${this._deviceName}
-            @close=${this._onCardClose}
-          ></ew-esp-device-card>`
-        : html`<esphome-card status="DONE">
-            <div class="card-header">Install over USB</div>
-            <div class="card-content">Installed. You can close this tab.</div>
-          </esphome-card>`;
+      return html`<esphome-card status="DONE">
+        <div class="card-header">
+          ${this._deviceName
+            ? html`Installed ${this._deviceName}`
+            : "Install over USB"}
+        </div>
+        <div class="card-content">
+          Installed and rebooting. You can close this tab. To view logs, open
+          web.esphome.io and connect to the device.
+        </div>
+      </esphome-card>`;
     }
     return html`
       <esphome-card
@@ -266,17 +264,23 @@ class EWWebFlash extends LitElement {
           detail: installing ? "Erasing…" : "Connecting to device…",
         });
       },
-      onClose: (success) => {
+      onClose: async (success) => {
         this._busy = false;
-        // Success leaves the port open; show the device card. On failure stay on
-        // the install card so the user can retry.
-        this._status = success ? "done" : "ready";
+        if (!success) {
+          this._status = "ready"; // failed: stay on the card so the user retries
+          return;
+        }
+        // Release the flash port so the rebooted device runs cleanly; the cached
+        // handle is unreliable after a native-USB re-enumeration anyway.
+        try {
+          await this._port?.close();
+        } catch {
+          // already closed / handle died on re-enumeration
+        }
+        this._port = null;
+        this._status = "done";
       },
     });
-  };
-
-  private _onCardClose = (): void => {
-    this._port = null;
   };
 
   private _fail(detail: string): void {


### PR DESCRIPTION
## What

ESPHome Device Builder can build firmware but cannot flash over USB when it runs over plain http (the Home Assistant add-on), because Web Serial needs a secure context. This adds a mode where Device Builder opens web.esphome.io in a new tab and hands it the compiled firmware over postMessage, so the flashing runs here in a secure context.

When the page is opened with a nonce in the URL hash, it announces itself to the opener, accepts the firmware frame only from its opener window and only when the one time nonce matches (the opener origin is arbitrary, so there is no origin allowlist), converts the transferred image to the form install-web expects, and runs the existing connect and install flow. The firmware never touches a server.

## Post-flash reset (affects all installs)

This also replaces install-web's bare-RTS `resetSerialDevice` with a reset strategy that boots the app (RTC-watchdog for S2/S3/C2/C3, `UsbJtagSerialReset` for native-USB chips, classic EN-pulse with GPIO0 released for UART bridges), mirroring the device-builder-frontend web-serial reset. Native USB-Serial-JTAG chips previously stayed in download mode after writeFlash; this fixes the normal Connect & Install flow too, not just the hand-off. Verified on an ESP32-S3 over USB-Serial-JTAG and on a classic chip over a UART bridge.

## Notes

Companion change is in esphome/device-builder-frontend#904; tracked in esphome/backlog#151. Opening as a draft while the Device Builder side is finalized.
